### PR TITLE
Restore missing dotfiles

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,28 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+        "no-unused-vars": "off",
+        "no-constant-condition": [
+            "error", { "checkLoops": false }
+        ]
+    }
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+.coverage
+.eslintrc.json
+.nyc_output/*
+buildspec.yml
+coverage/*
+dev/*
+docs/*
+index.ts
+tsconfig.json
+src/*


### PR DESCRIPTION
This change restores some dotfiles that were not included in the initial commit, which will allow successful runs of `npm run build` again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
