### PR TITLE
Release v0.1.0-preview.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ to write software that makes use of AmazonQLDB.
 
 See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developerguide/accessing.html) for information on connecting to AWS.
 
+The JavaScript AWS SDK needs to have AWS_SDK_LOAD_CONFIG environment variable set to a truthy value in order to read
+from the ~./.aws/config file.
+
+See [Setting Region](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html) page for more information.
+
 ### TypeScript 3.5.x
 
 The driver is written in, and requires, TypeScript 3.5.x. It will be automatically installed as a dependency. 
@@ -41,8 +46,8 @@ will be using the driver as a dependency.
 
 ```npm install ion-js```
 
-Then from within your package, you can call the use the driver. This example shows usage in TypeScript specifying the 
-ledger name:
+Then from within your package, you can now use the driver by importing it. This example shows usage in TypeScript 
+specifying the QLDB ledger name and a specific region:
 
 ```javascript
 import { PooledQldbDriver, QldbSession } from "amazon-qldb-driver-nodejs";
@@ -51,7 +56,7 @@ const testServiceConfigOptions = {
     region: "us-east-1"
 };
 
-const qldbDriver: PooledQldbDriver = new PooledQldbDriver(testServiceConfigOptions, "testLedger");
+const qldbDriver: PooledQldbDriver = new PooledQldbDriver("testLedger", testServiceConfigOptions));
 const qldbSession: QldbSession = await qldbDriver.getSession();
 
 for (const table of await qldbSession.getTableNames()) {
@@ -65,19 +70,25 @@ for (const table of await qldbSession.getTableNames()) {
 
 You can run the unit tests with this command:
 
-```
-$ npm run testWithCoverage
-```
+```npm test```
 
-The performance tests have a separate README.md within the performance folder.
+or
 
-### Documentation
+```npm run testWithCoverage```
+
+### Documentation 
 
 TypeDoc is used for documentation. You can generate HTML locally with the following:
 
 ```npm run doc```
 
 ## Release Notes
+
+### Release 0.1.0-preview.2 (November 12, 2019)
+
+* Fix a bug in the test command that caused unit tests to fail compilation.
+* Small clarifications to the README.
+* Addition of a valid `buildspec.yml` file for running unit tests via CodeBuild.
 
 ### Release 0.1.0-preview.1 (November 8, 2019)
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,20 @@
+version: 0.2 
+ 
+phases: 
+  install: 
+    runtime-versions: 
+      nodejs: 10
+  pre_build: 
+    commands: 
+      - echo Installing source NPM dependencies... 
+      - npm install 
+  build: 
+    commands: 
+      - echo Build started on `date` 
+      - echo Compiling the Node.js code
+      - npm run build
+      - echo Running tests
+      - npm test
+  post_build: 
+    commands: 
+      - echo Build completed on `date` 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "name": "amazon-qldb-driver-nodejs",
   "description": "The Node.js driver for working with Amazon Quantum Ledger Database",
-  "version": "0.1.0-preview.1",
+  "version": "0.1.0-preview.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {
@@ -20,6 +20,7 @@
     "aws-sdk": "^2.546.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "cross-env": "^6.0.3",
     "eslint": "^6.5.1",
     "eslint-plugin-jsdoc": "^15.12.0",
     "grunt": "^1.0.4",
@@ -40,8 +41,8 @@
     "doc": "typedoc --out docs ./src --exclude **/*.test.ts",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "npm run build",
-    "test": "set TS_NODE_COMPILER_OPTIONS={\"strict\":false} && mocha -r ts-node/register src/**/*.test.ts",
-    "testWithCoverage": "set TS_NODE_COMPILER_OPTIONS={\"strict\":false} && nyc -r lcov -e .ts -x \"*.test.ts\" mocha -r ts-node/register src/**/*.test.ts && nyc report"
+    "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"strict\\\":false} mocha -r ts-node/register src/**/*.test.ts",
+    "testWithCoverage": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"strict\\\":false} nyc -r lcov -e .ts -x \"*.test.ts\" mocha -r ts-node/register src/**/*.test.ts && nyc report"
   },
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
This change includes a few improvements to the driver:

- Clarifications and additional information on the README
- Addition of the buildspec.yml file that we use for CodeBuild builds of the repository
- Fixing a bug in the `test` and `testWithCoverage` commands that was causing tests
  to fail on macOS but pass on Windows.

This version of the driver was released on npm as v0.1.0-preview.2, so this change also
 bumps up the version and release notes to match.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
