### PR TITLE
Fix "Digests don't match" Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ TypeDoc is used for documentation. You can generate HTML locally with the follow
 
 ## Release Notes
 
+### Release 0.1.1-preview.2 (December 26, 2019)
+
+* Fix "Digests don't match" bug #8
+* Renamed src/logUtil.ts to src/LogUtil.ts to match PascalCase.
+
 ### Release 0.1.0-preview.2 (November 12, 2019)
 
 * Fix a bug in the test command that caused unit tests to fail compilation.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "dependencies": {
     "@types/node": "12.0.2",
     "ion-hash-js": "^1.0.2",
-    "semaphore-async-await": "^1.5.1",
-    "stream": "0.0.2"
+    "semaphore-async-await": "^1.5.1"
   },
   "name": "amazon-qldb-driver-nodejs",
   "description": "The Node.js driver for working with Amazon Quantum Ledger Database",

--- a/src/Communicator.ts
+++ b/src/Communicator.ts
@@ -26,7 +26,7 @@ import {
 } from "aws-sdk/clients/qldbsession";
 import { inspect } from "util";
 
-import { debug, warn } from "./logUtil";
+import { debug, warn } from "./LogUtil";
 
 /**
  * A class representing an independent session to a QLDB ledger that handles endpoint requests. This class is used in

--- a/src/PooledQldbDriver.ts
+++ b/src/PooledQldbDriver.ts
@@ -16,7 +16,7 @@ import { globalAgent } from "http";
 import Semaphore from "semaphore-async-await";
 
 import { DriverClosedError, SessionPoolEmptyError } from "./errors/Errors";
-import { debug } from "./logUtil";
+import { debug } from "./LogUtil";
 import { PooledQldbSession } from "./PooledQldbSession";
 import { QldbDriver } from "./QldbDriver";
 import { QldbSession } from "./QldbSession";

--- a/src/QldbDriver.ts
+++ b/src/QldbDriver.ts
@@ -17,7 +17,7 @@ import { ClientConfiguration } from "aws-sdk/clients/qldbsession";
 import { version } from "../package.json";
 import { Communicator } from "./Communicator";
 import { DriverClosedError } from "./errors/Errors";
-import { debug } from "./logUtil";
+import { debug } from "./LogUtil";
 import { QldbSession } from "./QldbSession";
 import { QldbSessionImpl } from "./QldbSessionImpl";
 

--- a/src/QldbHash.ts
+++ b/src/QldbHash.ts
@@ -13,7 +13,7 @@
 
 import { createHash } from "crypto";
 import { cryptoHasherProvider, HashReader, makeHashReader } from "ion-hash-js";
-import { makeReader } from "ion-js";
+import { makeReader, makeTextWriter, Writer } from "ion-js";
 
 const HASH_SIZE: number = 32
 
@@ -72,7 +72,10 @@ export class QldbHash {
      */
     static toQldbHash(value: any): QldbHash {
         if (typeof value === "string") {
-            value = "\"" + value + "\"";
+            const writer: Writer = makeTextWriter();
+            writer.writeString(value);
+            writer.close();
+            value = writer.getBytes();
         }
         const hashReader: HashReader = makeHashReader(makeReader(value), cryptoHasherProvider("sha256"));
         hashReader.next();

--- a/src/QldbSessionImpl.ts
+++ b/src/QldbSessionImpl.ts
@@ -24,7 +24,7 @@ import {
     LambdaAbortedError,
     SessionClosedError
 } from "./errors/Errors";
-import { info, warn } from "./logUtil";
+import { info, warn } from "./LogUtil";
 import { QldbSession } from "./QldbSession";
 import { QldbWriter } from "./QldbWriter";
 import { Result } from "./Result";

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -18,7 +18,7 @@ import { Readable } from "stream";
 
 import { Communicator } from "./Communicator";
 import { ClientException, isOccConflictException, TransactionClosedError } from "./errors/Errors";
-import { warn } from "./logUtil";
+import { warn } from "./LogUtil";
 import { QldbHash } from "./QldbHash";
 import { QldbWriter } from "./QldbWriter";
 import { Result } from "./Result";

--- a/src/errors/Errors.ts
+++ b/src/errors/Errors.ts
@@ -13,9 +13,9 @@
 
 import { AWSError } from "aws-sdk";
 
-import { error } from "../logUtil";
+import { error } from "../LogUtil";
 
-class ClientException extends Error {
+export class ClientException extends Error {
     constructor(message: string) {
         super(message);
         Object.setPrototypeOf(this, ClientException.prototype)
@@ -25,7 +25,7 @@ class ClientException extends Error {
     }
 }
 
-class DriverClosedError extends Error {
+export class DriverClosedError extends Error {
     constructor() {
         const message: string = "Cannot invoke methods on a closed driver. Please create a new driver and retry.";
         super(message);
@@ -36,7 +36,7 @@ class DriverClosedError extends Error {
     }
 }
 
-class LambdaAbortedError extends Error {
+export class LambdaAbortedError extends Error {
     constructor() {
         const message: string = "Abort called. Halting execution of lambda function.";
         super(message);
@@ -47,7 +47,7 @@ class LambdaAbortedError extends Error {
     }
 }
 
-class SessionClosedError extends Error {
+export class SessionClosedError extends Error {
     constructor() {
         const message: string = "Cannot invoke methods on a closed QldbSession. Please create a new session and retry.";
         super(message);
@@ -58,7 +58,7 @@ class SessionClosedError extends Error {
     }
 }
 
-class SessionPoolEmptyError extends Error {
+export class SessionPoolEmptyError extends Error {
     constructor(timeout: number) {
         const message: string =
             `Session pool is empty after waiting for ${timeout} milliseconds. Please close existing sessions first ` +
@@ -71,7 +71,7 @@ class SessionPoolEmptyError extends Error {
     }
 }
 
-class TransactionClosedError extends Error {
+export class TransactionClosedError extends Error {
     constructor() {
         const message: string =
             "Cannot invoke methods on a closed Transaction. Please create a new transaction and retry.";
@@ -88,7 +88,7 @@ class TransactionClosedError extends Error {
  * @param e The client error caught.
  * @returns True if the exception is an InvalidParameterException. False otherwise.
  */
-function isInvalidParameterException(e: AWSError): boolean {
+export function isInvalidParameterException(e: AWSError): boolean {
     return e.code === "InvalidParameterException";
 }
 
@@ -97,7 +97,7 @@ function isInvalidParameterException(e: AWSError): boolean {
  * @param e The client error caught.
  * @returns True if the exception is an InvalidSessionException. False otherwise.
  */
-function isInvalidSessionException(e: AWSError): boolean {
+export function isInvalidSessionException(e: AWSError): boolean {
     return e.code === "InvalidSessionException";
 }
 
@@ -106,7 +106,7 @@ function isInvalidSessionException(e: AWSError): boolean {
  * @param e The client error caught.
  * @returns True if the exception is an OccConflictException. False otherwise.
  */
-function isOccConflictException(e: AWSError): boolean {
+export function isOccConflictException(e: AWSError): boolean {
     return e.code === "OccConflictException";
 }
 
@@ -115,7 +115,7 @@ function isOccConflictException(e: AWSError): boolean {
  * @param e The client error to check to see if it is a ResourceNotFoundException.
  * @returns Whether or not the exception is a ResourceNotFoundException.
  */
-function isResourceNotFoundException(e: AWSError): boolean {
+export function isResourceNotFoundException(e: AWSError): boolean {
     return e.code === "ResourceNotFoundException";
 }
 
@@ -124,7 +124,7 @@ function isResourceNotFoundException(e: AWSError): boolean {
  * @param e The client error to check to see if it is a ResourcePreconditionNotMetException.
  * @returns Whether or not the exception is a ResourcePreconditionNotMetException.
  */
-function isResourcePreconditionNotMetException(e: AWSError): boolean {
+export function isResourcePreconditionNotMetException(e: AWSError): boolean {
     return e.code === "ResourcePreconditionNotMetException";
 }
 
@@ -133,24 +133,9 @@ function isResourcePreconditionNotMetException(e: AWSError): boolean {
  * @param e The client error caught.
  * @returns True if the exception is a retriable exception. False otherwise.
  */
-function isRetriableException(e: AWSError): boolean {
+export function isRetriableException(e: AWSError): boolean {
     return (e.statusCode === 500) ||
            (e.statusCode === 503) ||
            (e.code === "NoHttpResponseException") ||
            (e.code === "SocketTimeoutException");
 }
-
-export {
-    ClientException,
-    DriverClosedError,
-    isInvalidParameterException,
-    isInvalidSessionException,
-    isOccConflictException,
-    isResourceNotFoundException,
-    isResourcePreconditionNotMetException,
-    isRetriableException,
-    LambdaAbortedError,
-    SessionClosedError,
-    SessionPoolEmptyError,
-    TransactionClosedError
-};

--- a/src/test/Communicator.test.ts
+++ b/src/test/Communicator.test.ts
@@ -30,7 +30,7 @@ import * as chaiAsPromised from "chai-as-promised";
 import * as sinon from "sinon";
 
 import { Communicator } from "../Communicator";
-import * as logUtil from "../logUtil";
+import * as LogUtil from "../LogUtil";
 
 chai.use(chaiAsPromised);
 const sandbox = sinon.createSandbox();
@@ -249,7 +249,7 @@ describe("Communicator", () => {
                     throw new Error(testMessage);
                 }
             });
-            const logSpy = sandbox.spy(logUtil, "warn");
+            const logSpy = sandbox.spy(LogUtil, "warn");
             await communicator.endSession();
             const testRequest: SendCommandRequest = {
                 EndSession: {},

--- a/src/test/Errors.test.ts
+++ b/src/test/Errors.test.ts
@@ -33,7 +33,7 @@ import {
     SessionPoolEmptyError,
     TransactionClosedError
 } from "../errors/Errors";
-import * as logUtil from "../logUtil";
+import * as LogUtil from "../LogUtil";
 
 chai.use(chaiAsPromised);
 const sandbox = sinon.createSandbox();
@@ -51,7 +51,7 @@ describe("Errors", () => {
 
     describe("#ClientException", () => {
         it("should be a ClientException when new ClientException created", () => {
-            const logSpy = sandbox.spy(logUtil, "error");
+            const logSpy = sandbox.spy(LogUtil, "error");
             const error = new ClientException(testMessage);
             chai.expect(error).to.be.instanceOf(ClientException);
             chai.assert.equal(error.name, "ClientException");
@@ -62,7 +62,7 @@ describe("Errors", () => {
 
     describe("#DriverClosedError", () => {
         it("should be a DriverClosedError when new DriverClosedError created", () => {
-            const logSpy = sandbox.spy(logUtil, "error");
+            const logSpy = sandbox.spy(LogUtil, "error");
             const error = new DriverClosedError();
             chai.expect(error).to.be.instanceOf(DriverClosedError);
             chai.assert.equal(error.name, "DriverClosedError");
@@ -72,7 +72,7 @@ describe("Errors", () => {
 
     describe("#LambdaAbortedError", () => {
         it("should be a LambdaAbortedError when new LambdaAbortedError created", () => {
-            const logSpy = sandbox.spy(logUtil, "error");
+            const logSpy = sandbox.spy(LogUtil, "error");
             const error = new LambdaAbortedError();
             chai.expect(error).to.be.instanceOf(LambdaAbortedError);
             chai.assert.equal(error.name, "LambdaAbortedError");
@@ -82,7 +82,7 @@ describe("Errors", () => {
 
     describe("#SessionClosedError", () => {
         it("should be a SessionClosedError when new SessionClosedError created", () => {
-            const logSpy = sandbox.spy(logUtil, "error");
+            const logSpy = sandbox.spy(LogUtil, "error");
             const error = new SessionClosedError();
             chai.expect(error).to.be.instanceOf(SessionClosedError);
             chai.assert.equal(error.name, "SessionClosedError");
@@ -92,7 +92,7 @@ describe("Errors", () => {
 
     describe("#SessionPoolEmptyError", () => {
         it("should be a SessionPoolEmptyError when new SessionPoolEmptyError created", () => {
-            const logSpy = sandbox.spy(logUtil, "error");
+            const logSpy = sandbox.spy(LogUtil, "error");
             const error = new SessionPoolEmptyError(1);
             chai.expect(error).to.be.instanceOf(SessionPoolEmptyError);
             chai.assert.equal(error.name, "SessionPoolEmptyError");
@@ -102,7 +102,7 @@ describe("Errors", () => {
 
     describe("#TransactionClosedError", () => {
         it("should be a TransactionClosedError when new TransactionClosedError created", () => {
-            const logSpy = sandbox.spy(logUtil, "error");
+            const logSpy = sandbox.spy(LogUtil, "error");
             const error = new TransactionClosedError();
             chai.expect(error).to.be.instanceOf(TransactionClosedError);
             chai.assert.equal(error.name, "TransactionClosedError");

--- a/src/test/PooledQldbDriver.test.ts
+++ b/src/test/PooledQldbDriver.test.ts
@@ -23,7 +23,7 @@ import Semaphore from "semaphore-async-await";
 import * as sinon from "sinon";
 
 import { DriverClosedError, SessionPoolEmptyError } from "../errors/Errors";
-import * as logUtil from "../logUtil";
+import * as LogUtil from "../LogUtil";
 import { PooledQldbDriver } from "../PooledQldbDriver";
 import { QldbDriver } from "../QldbDriver";
 import { QldbSessionImpl } from "../QldbSessionImpl";
@@ -152,7 +152,7 @@ describe("PooledQldbDriver", () => {
             semaphoreStub.returns(Promise.resolve(true));
 
             const qldbDriverGetSessionSpy = sandbox.spy(QldbDriver.prototype, "getSession");
-            const logDebugSpy = sandbox.spy(logUtil, "debug");
+            const logDebugSpy = sandbox.spy(LogUtil, "debug");
 
             const pooledQldbSession: QldbSession = await pooledQldbDriver.getSession();
 
@@ -175,7 +175,7 @@ describe("PooledQldbDriver", () => {
             pooledQldbDriver["_sessionPool"] = [mockSession];
             pooledQldbDriver["_qldbClient"] = testQldbLowLevelClient;
 
-            const logDebugSpy = sandbox.spy(logUtil, "debug");
+            const logDebugSpy = sandbox.spy(LogUtil, "debug");
             const abortOrCloseSpy = sandbox.spy(mockSession as any, "_abortOrClose");
 
             const semaphoreStub = sandbox.stub(pooledQldbDriver["_semaphore"], "waitFor");
@@ -214,7 +214,7 @@ describe("PooledQldbDriver", () => {
 
     describe("#releaseSession()", () => {
         it("should return a session back to the session pool when called", () => {
-            const logDebugSpy = sandbox.spy(logUtil, "debug");
+            const logDebugSpy = sandbox.spy(LogUtil, "debug");
             const semaphoreReleaseSpy = sandbox.spy(pooledQldbDriver["_semaphore"], "release")
             const mockSession: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
 

--- a/src/test/PooledQldbSession.test.ts
+++ b/src/test/PooledQldbSession.test.ts
@@ -18,7 +18,7 @@ import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 import * as sinon from "sinon";
 
-import * as logUtil from "../logUtil";
+import * as LogUtil from "../LogUtil";
 import { SessionClosedError } from "../errors/Errors";
 import { PooledQldbSession } from "../PooledQldbSession";
 import { QldbSessionImpl } from "../QldbSessionImpl";
@@ -29,7 +29,7 @@ import { Transaction } from "../Transaction";
 chai.use(chaiAsPromised);
 const sandbox = sinon.createSandbox();
 
-const testLambda = () => logUtil.log("Test returning session to pool...");
+const testLambda = () => LogUtil.log("Test returning session to pool...");
 const testLedgerName: string = "fakeLedgerName";
 const testMessage: string = "foo";
 const testSessionToken: string = "sessionToken";
@@ -80,7 +80,7 @@ describe("PooledQldbSession", () => {
 
     describe("#close()", () => {
         it("should close pooledQldbSession and execute the lambda when called", () => {
-            const logSpy = sandbox.spy(logUtil, "log");
+            const logSpy = sandbox.spy(LogUtil, "log");
             pooledQldbSession.close();
             chai.assert.equal(pooledQldbSession["_isClosed"], true);
             sinon.assert.calledOnce(logSpy);
@@ -88,7 +88,7 @@ describe("PooledQldbSession", () => {
         });
 
         it("should be a no-op when already closed", () => {
-            const logSpy = sandbox.spy(logUtil, "log");
+            const logSpy = sandbox.spy(LogUtil, "log");
             pooledQldbSession["_isClosed"] = true;
             pooledQldbSession.close();
             sinon.assert.notCalled(logSpy);

--- a/src/test/QldbSession.test.ts
+++ b/src/test/QldbSession.test.ts
@@ -33,7 +33,7 @@ import { format } from "util";
 
 import { Communicator } from "../Communicator";
 import * as Errors from "../errors/Errors";
-import * as logUtil from "../logUtil";
+import * as LogUtil from "../LogUtil";
 import { QldbSessionImpl } from "../QldbSessionImpl";
 import { createQldbWriter, QldbWriter } from "../QldbWriter";
 import { Result } from "../Result";
@@ -215,7 +215,7 @@ describe("QldbSession", () => {
 
             const startTransactionSpy = sandbox.spy(qldbSession, "startTransaction");
             const noThrowAbortSpy = sandbox.spy(qldbSession as any, "_noThrowAbort");
-            const logSpy = sandbox.spy(logUtil, "warn");
+            const logSpy = sandbox.spy(LogUtil, "warn");
 
             await chai.expect(qldbSession.executeLambda(async (txn) => {
                 throw new Error(testMessage);
@@ -232,7 +232,7 @@ describe("QldbSession", () => {
 
             const startTransactionSpy = sandbox.spy(qldbSession, "startTransaction");
             const noThrowAbortSpy = sandbox.spy(qldbSession as any, "_noThrowAbort");
-            const logSpy = sandbox.spy(logUtil, "warn");
+            const logSpy = sandbox.spy(LogUtil, "warn");
 
             await chai.expect(qldbSession.executeLambda(async (txn) => {
                 throw new Error(testMessage);
@@ -247,8 +247,8 @@ describe("QldbSession", () => {
             const isInvalidSessionStub = sandbox.stub(Errors, "isInvalidSessionException");
             isInvalidSessionStub.returns(true);
 
-            const logWarnSpy = sandbox.spy(logUtil, "warn");
-            const logInfoSpy = sandbox.spy(logUtil, "info");
+            const logWarnSpy = sandbox.spy(LogUtil, "warn");
+            const logInfoSpy = sandbox.spy(LogUtil, "info");
 
             Communicator.create = async () => {
                 return mockCommunicator;
@@ -268,12 +268,12 @@ describe("QldbSession", () => {
             const isRetriableStub = sandbox.stub(Errors, "isRetriableException");
             isRetriableStub.returns(true);
             const retryIndicator = () =>
-                logUtil.log("Retrying test retry indicator...");
+                LogUtil.log("Retrying test retry indicator...");
 
             const startTransactionSpy = sandbox.spy(qldbSession, "startTransaction");
             const noThrowAbortSpy = sandbox.spy(qldbSession as any, "_noThrowAbort");
-            const logSpy = sandbox.spy(logUtil, "warn");
-            const retryIndicatorSpy = sandbox.spy(logUtil, "log");
+            const logSpy = sandbox.spy(LogUtil, "warn");
+            const retryIndicatorSpy = sandbox.spy(LogUtil, "log");
 
             await chai.expect(qldbSession.executeLambda(async (txn) => {
                 throw new Error(testMessage);
@@ -418,7 +418,7 @@ describe("QldbSession", () => {
             mockTransaction.abort = async () => {
                 throw new Error(testMessage);
             };
-            const logSpy = sandbox.spy(logUtil, "warn");
+            const logSpy = sandbox.spy(LogUtil, "warn");
             const communicatorAbortSpy = sandbox.spy(mockCommunicator, "abortTransaction");
             const transactionAbortSpy = sandbox.spy(mockTransaction, "abort");
             await qldbSession["_noThrowAbort"](mockTransaction);


### PR DESCRIPTION
 - resolves #8 - "Digests don't match"

   The digest calculated by the driver turned out to be incorrect when the table name in
   the partiql query is enclosed within quotes. This happened because of incorrect arguments
   being passed to ion-hash-js library.

 - Rename src/logUtil.ts to src/LogUtil.ts to match PascalCase.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
