### PR TITLE
hotfix(executeStatement): changed second argument as option

### DIFF
--- a/src/QldbSession.ts
+++ b/src/QldbSession.ts
@@ -75,7 +75,7 @@ export interface QldbSession {
      * @throws {@linkcode SessionClosedError} when the session is closed.
      */
     executeStatement: (statement: string,
-                       parameters: QldbWriter[],
+                       parameters?: QldbWriter[],
                        retryIndicator?: (retryAttempt: number) => void) => Promise<Result>;
 
     /**


### PR DESCRIPTION
In executeStatement the second parameter is defined as  optional and yet it is marked mandatory in function parameters
So I have changed it to optional.

#Issue
Unable to use executeStatement with one Parameter in typescript nodejs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
