### PR TITLE
Fix compilation error on @types/chai v4.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.8.10"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.3",
+    "@types/chai": "4.2.10",
     "@types/chai-as-promised": "^7.1.2",
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.0.13",

--- a/src/test/PooledQldbDriver.test.ts
+++ b/src/test/PooledQldbDriver.test.ts
@@ -91,28 +91,28 @@ describe("PooledQldbDriver", () => {
         });
 
         it("should throw a RangeError when timeOutMillis less than zero passed in", () => {
-            const constructorFunction: Function = () => {
+            const constructorFunction: () => void = () => {
                 new PooledQldbDriver(testLedgerName, testLowLevelClientOptions, 4, 0, -1);
             };
             chai.assert.throws(constructorFunction, RangeError);
         });
 
         it("should throw a RangeError when retryLimit less than zero passed in", () => {
-            const constructorFunction: Function = () => {
+            const constructorFunction: () => void = () => {
                 new PooledQldbDriver(testLedgerName, testLowLevelClientOptions, -1);
             };
             chai.assert.throws(constructorFunction, RangeError);
         });
 
         it("should throw a RangeError when poolLimit greater than maxSockets", () => {
-            const constructorFunction: Function = () => {
+            const constructorFunction: () => void  = () => {
                 new PooledQldbDriver(testLedgerName, testLowLevelClientOptions, 4, testMaxSockets + 1);
             };
             chai.assert.throws(constructorFunction, RangeError);
         });
 
         it("should throw a RangeError when poolLimit less than zero", () => {
-            const constructorFunction: Function = () => {
+            const constructorFunction: () => void = () => {
                 new PooledQldbDriver(testLedgerName, testLowLevelClientOptions, 4, -1);
             };
             chai.assert.throws(constructorFunction, RangeError);

--- a/src/test/QldbDriver.test.ts
+++ b/src/test/QldbDriver.test.ts
@@ -70,7 +70,7 @@ describe("QldbDriver", () => {
         });
 
         it("should throw RangeError when retryLimit less than zero passed in", () => {
-            const constructorFunction: Function = () => {
+            const constructorFunction: () => void = () => {
                 new QldbDriver(testLedgerName, testLowLevelClientOptions, -1);
             };
             chai.assert.throws(constructorFunction, RangeError);


### PR DESCRIPTION
While running npm test, the PooledDriverTest began to fail. Investigation revealed that @types/chai caused the breaking change. This code change fixes the test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
