### PR TITLE
[v1.0.0-rc.1]Introduce Ion DOM support, driver level executeLambda method and varargs for transaction execute method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# 1.0.0-rc.1 (2020-04-03)
+
+## :boom: Breaking changes
+
+* [(#22)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/22) `executeInline` method renamed to `execute` and `executeStream` method renamed to `executeAndStreamResults`.
+* [(#23)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/23) `execute` and `executeAndStreamResults`  methods  accept JavaScript built-in data types(and [Ion Value data types](https://github.com/amzn/ion-js/blob/master/src/dom/README.md#iondom-data-types))  instead of `IonWriter` type.
+* [(#24)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/24) `execute` and `executeAndStreamResults` method accepts variable number of arguments instead of passing an array of arguments.
+* [(#25)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/25) Query results will be returned as an  [Ion Value](https://github.com/amzn/ion-js/blob/master/src/dom/Value.ts)  instead of  an `IonReader` when running the PartiQL query via `execute` and/or `executeAndStreamResults`
+* Removed `executeStatement` method from Qldb Session.
+* Target version changed to ES6
+
+## :tada: Enhancements
+
+* [(#5)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/5) The Ion Value results returned by `execute` and `executeAndStreamResults` can be converted into JSON String via `JSON.stringify(result)`  
+
+* [(#26)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/26) Introduced `executeLambda` method on Qldb Driver.
+
+  
+
+# 0.1.2-preview.1 (2020-03-06)
+
+## :bug: Fixes
+
+* "Error: stream.push() after EOF" bug [#7](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/7)
+* On reading from ResultStream, potential event listeners might not have received an error. Error fixed by rightly calling the destroy method and passing the error to it.
+* On starting a transaction, on consuming the resultstream, the last value could sometimes show up twice. 
+
+# 0.1.1-preview.2 (2019-12-26)
+
+## :bug: Fix
+
+* "Digests don't match" bug [#8](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/8)
+
+## :nut_and_bolt: Other​ 
+
+* Renamed src/logUtil.ts to src/LogUtil.ts to match PascalCase.
+
+# 0.1.0-preview.2 (2019-11-12)
+
+## :bug: Fix
+
+* Fix a bug in the test command that caused unit tests to fail compilation.
+
+## :tada: Enhancement
+
+* Add a valid `buildspec.yml` file for running unit tests via CodeBuild.
+
+## :book: Documentation
+
+* Small clarifications to the README.
+
+# 0.1.0-preview.1 (2019-11-08)
+
+* Preview release of the driver.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Amazon QLDB Node.js Driver
 
-[![NPM Version](https://img.shields.io/badge/npm-v1.0.0--rc.1-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs)[![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
+[![NPM Version](https://img.shields.io/badge/npm-v1.0.0--rc.1-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs) 
+[![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
 
 This is the Node.js driver for Amazon Quantum Ledger Database (QLDB), which allows Node.js developers
 to write software that makes use of AmazonQLDB.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Amazon QLDB Node.js Driver
 
+[![NPM Version](https://img.shields.io/badge/npm-v1.0.0--rc.1-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs)[![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
+
 This is the Node.js driver for Amazon Quantum Ledger Database (QLDB), which allows Node.js developers
 to write software that makes use of AmazonQLDB.
 
 **This is a preview release of the Amazon QLDB Driver for Node.js, and we do not recommend that it be used for production purposes.**
+
 
 ## Requirements
 
@@ -93,30 +96,6 @@ or
 TypeDoc is used for documentation. You can generate HTML locally with the following:
 
 ```npm run doc```
-
-## Release Notes
-
-### Release 0.1.2-preview.1
-
-* Fix : "Error: stream.push() after EOF" bug [#7](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/7)
-* Fix : On reading from ResultStream, potential event listeners might not have received an error. Error fixed by rightly calling the destroy method and passing the error to it.
-* Fix : On starting a transaction, on consuming the resultstream, the last value could sometimes show up twice.
-
-### Release 0.1.1-preview.2 (December 26, 2019)
-
-
-* Fix "Digests don't match" bug [#8](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/8)
-* Renamed src/logUtil.ts to src/LogUtil.ts to match PascalCase.
-
-### Release 0.1.0-preview.2 (November 12, 2019)
-
-* Fix a bug in the test command that caused unit tests to fail compilation.
-* Small clarifications to the README.
-* Addition of a valid `buildspec.yml` file for running unit tests via CodeBuild.
-
-### Release 0.1.0-preview.1 (November 8, 2019)
-
-Preview release of the driver.
 
 ## License
 

--- a/index.ts
+++ b/index.ts
@@ -5,10 +5,12 @@ export {
     isResourceNotFoundException,
     isResourcePreconditionNotMetException
 } from "./src/errors/Errors";
+export { Executable } from "./src/Executable";
 export { PooledQldbDriver } from "./src/PooledQldbDriver";
 export { QldbDriver } from "./src/QldbDriver";
 export { QldbSession } from "./src/QldbSession";
 export { createQldbWriter, QldbWriter } from "./src/QldbWriter";
 export { Result } from "./src/Result";
 export { Transaction } from "./src/Transaction";
+export { TransactionExecutable } from "./src/TransactionExecutable";
 export { TransactionExecutor } from "./src/TransactionExecutor";

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
     "@types/node": "12.0.2",
-    "ion-hash-js": "^1.0.2",
+    "ion-hash-js": "2.0.0",
     "semaphore-async-await": "^1.5.1"
   },
   "name": "amazon-qldb-driver-nodejs",
   "description": "The Node.js driver for working with Amazon Quantum Ledger Database",
-  "version": "0.1.2-preview.1",
+  "version": "1.0.0-rc.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
@@ -26,7 +26,8 @@
     "eslint": "^6.5.1",
     "eslint-plugin-jsdoc": "^15.12.0",
     "grunt": "^1.0.4",
-    "ion-js": "~3.1.2",
+    "ion-js": "~4.0.0",
+    "jsbi": "~3.1.1",
     "mocha": "^6.2.0",
     "nyc": "^14.1.1",
     "sinon": "^7.3.2",
@@ -36,7 +37,7 @@
   },
   "peerDependencies": {
     "aws-sdk": "^2.546.0",
-    "ion-js": "^3.1.2"
+    "ion-js": "~4.0.0"
   },
   "scripts": {
     "build": "npm run lint && tsc",

--- a/src/Executable.ts
+++ b/src/Executable.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { TransactionExecutor } from "./TransactionExecutor";
+
+/**
+ * Interface for execution against QLDB.
+ */
+export interface Executable {
+    /**
+     * Execute a lambda within a new transaction and commit the transaction, retrying up to the retry limit if an OCC 
+     * conflict or retriable exception occurs.
+     * 
+     * @param queryLambda A lambda representing the block of code to be executed within the transaction. This cannot 
+     *                    have any side effects as it may be invoked multiple times, and the result cannot be trusted 
+     *                    until the transaction is committed.
+     * @param retryIndicator An optional lambda that is invoked when the `querylambda` is about to be retried due to an 
+     *                       OCC conflict or retriable exception.
+     * @returns Promise which fulfills with the return value of the `queryLambda` which could be a {@linkcode Result} 
+     *          on the result set of a statement within the lambda.
+     */
+    executeLambda: (queryLambda: (transactionExecutor: TransactionExecutor) => any,
+                    retryIndicator?: (retryAttempt: number) => void) => Promise<any>;
+}

--- a/src/PooledQldbSession.ts
+++ b/src/PooledQldbSession.ts
@@ -14,8 +14,6 @@
 import { SessionClosedError } from "./errors/Errors";
 import { QldbSession } from "./QldbSession";
 import { QldbSessionImpl } from "./QldbSessionImpl";
-import { QldbWriter } from "./QldbWriter";
-import { Result } from "./Result";
 import { Transaction } from "./Transaction";
 import { TransactionExecutor } from "./TransactionExecutor";
 
@@ -68,26 +66,6 @@ export class PooledQldbSession implements QldbSession {
     ): Promise<any> {
         this._throwIfClosed()
         return await this._session.executeLambda(queryLambda, retryIndicator);
-    }
-    
-    /**
-     * Implicitly start a transaction, execute the statement, and commit the transaction, retrying up to the
-     * retry limit if an OCC conflict or retriable exception occurs.
-     * 
-     * @param statement The statement to execute.
-     * @param parameters An optional list of QLDB writers containing Ion values to execute.
-     * @param retryIndicator An optional lambda that is invoked when the `statement` is about to be retried due to an 
-     *                       OCC conflict or retriable exception.
-     * @returns Promise which fulfills with a Result.
-     * @throws {@linkcode SessionClosedError} when this session is closed.
-     */
-    async executeStatement(
-        statement: string, 
-        parameters: QldbWriter[] = [],
-        retryIndicator?: (retryAttempt: number) => void
-    ): Promise<Result> {
-        this._throwIfClosed();
-        return await this._session.executeStatement(statement, parameters, retryIndicator);
     }
 
     /**

--- a/src/QldbDriver.ts
+++ b/src/QldbDriver.ts
@@ -72,11 +72,19 @@ export class QldbDriver {
      * @throws {@linkcode DriverClosedError} when this driver is closed.
      */
     async getSession(): Promise<QldbSession> {
-        if (this._isClosed) {
-            throw new DriverClosedError();
-        }
+        this._throwIfClosed();
         debug("Creating a new session.");
         const communicator: Communicator = await Communicator.create(this._qldbClient, this._ledgerName);
         return new QldbSessionImpl(communicator, this._retryLimit);
+    }
+
+    /**
+     * Check and throw if this driver is closed.
+     * @throws {@linkcode DriverClosedError} when this driver is closed.
+     */
+    protected _throwIfClosed(): void {
+        if (this._isClosed) {
+            throw new DriverClosedError();
+        }
     }
 }

--- a/src/QldbSession.ts
+++ b/src/QldbSession.ts
@@ -11,10 +11,8 @@
  * and limitations under the License.
  */
 
-import { Result } from "./Result";
-import { QldbWriter } from "./QldbWriter";
+import { Executable } from "./Executable";
 import { Transaction } from "./Transaction";
-import { TransactionExecutor } from "./TransactionExecutor";
 
 /**
  * The top-level interface for a QldbSession object for interacting with QLDB. A QldbSession is linked to the specified 
@@ -40,43 +38,12 @@ import { TransactionExecutor } from "./TransactionExecutor";
  *    leaves the responsibility of OCC conflict handling up to the user. Transactions' methods cannot be automatically 
  *    retried, as the state of the transaction is ambiguous in the case of an unexpected error.
  */
-export interface QldbSession {
+export interface QldbSession extends Executable {
     
     /**
      * Close this session. No-op if already closed.
      */
     close: () => void;
-
-    /**
-     * Implicitly start a transaction, execute the lambda, and commit the transaction, retrying up to the
-     * retry limit if an OCC conflict or retriable exception occurs.
-     * 
-     * @param queryLambda A lambda representing the block of code to be executed within the transaction. This cannot 
-     *                    have any side effects as it may be invoked multiple times, and the result cannot be trusted 
-     *                    until the transaction is committed.
-     * @param retryIndicator An optional lambda that is invoked when the `querylambda` is about to be retried due to an 
-     *                       OCC conflict or retriable exception.
-     * @returns Promise which fulfills with the return value of the `queryLambda` which could be a {@linkcode Result} 
-     *          on the result set of a statement within the lambda.
-     * @throws {@linkcode SessionClosedError} when this session is closed.
-     */
-    executeLambda: (queryLambda: (transactionExecutor: TransactionExecutor) => any,
-                    retryIndicator?: (retryAttempt: number) => void) => Promise<any>;
-
-    /**
-     * Implicitly start a transaction, execute the statement, and commit the transaction, retrying up to the
-     * retry limit if an OCC conflict or retriable exception occurs.
-     * 
-     * @param statement The statement to execute.
-     * @param parameters An optional list of QLDB writers containing Ion values to execute.
-     * @param retryIndicator An optional lambda that is invoked when the `statement` is about to be retried due to an 
-     *                       OCC conflict or retriable exception.
-     * @returns Promise which fulfills with a Result.
-     * @throws {@linkcode SessionClosedError} when the session is closed.
-     */
-    executeStatement: (statement: string,
-                       parameters: QldbWriter[],
-                       retryIndicator?: (retryAttempt: number) => void) => Promise<Result>;
 
     /**
      * Return the name of the ledger for the session.

--- a/src/ResultStream.ts
+++ b/src/ResultStream.ts
@@ -12,7 +12,7 @@
  */
 
 import { FetchPageResult, Page } from "aws-sdk/clients/qldbsession";
-import { makeReader, Reader } from "ion-js";
+import { dom } from "ion-js";
 import { Readable } from "stream";
 
 import { Communicator } from "./Communicator";
@@ -62,7 +62,7 @@ export class ResultStream extends Readable {
 
     /**
      * Pushes the values for the Node Streams Readable Interface. This method fetches the next page if is required and
-     * handles converting the values returned from QLDB into a Reader.
+     * handles converting the values returned from QLDB into an Ion value.
      * @returns Promise which fulfills with void.
      */
     private async _pushPageValues(): Promise<void> {
@@ -84,9 +84,9 @@ export class ResultStream extends Readable {
             }
 
             while (this._retrieveIndex < this._cachedPage.Values.length) {
-                const reader: Reader = 
-                    makeReader(Result._handleBlob(this._cachedPage.Values[this._retrieveIndex++].IonBinary));
-                canPush = this.push(reader);
+                const ionValue: dom.Value =
+                    dom.load(Result._handleBlob(this._cachedPage.Values[this._retrieveIndex++].IonBinary));
+                canPush = this.push(ionValue);
                 if (!canPush) {
                     this._shouldPushCachedPage = this._retrieveIndex < this._cachedPage.Values.length;
                     return;

--- a/src/TransactionExecutable.ts
+++ b/src/TransactionExecutable.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { Readable } from "stream";
+
+import { Result } from "./Result";
+
+/**
+ * Interface for execution against QLDB in the context of a transaction.
+ */
+export interface TransactionExecutable {
+    /**
+     * Execute the specified statement in the current transaction.
+     * @param statement A statement to execute against QLDB as a string.
+     * @param parameters Rest parameters of Ion values or JavaScript native types that are convertible to Ion for
+     *                   filling in parameters of the statement.
+     * @returns Promise which fulfills with a fully-buffered Result.
+     */
+    execute(statement: string, ...parameters: any[]): Promise<Result>;
+
+    /**
+     * Execute the specified statement in the current transaction.
+     * @param statement A statement to execute against QLDB as a string.
+     * @param parameters Rest parameters of Ion values or JavaScript native types that are convertible to Ion for
+     *                   filling in parameters of the statement.
+     * @returns Promise which fulfills with a Readable.
+     */
+    executeAndStreamResults(statement: string, ...parameters: any[]): Promise<Readable>;
+}

--- a/src/test/ResultStream.test.ts
+++ b/src/test/ResultStream.test.ts
@@ -17,12 +17,10 @@ import "mocha";
 import { Page, ValueHolder } from "aws-sdk/clients/qldbsession";
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
-import * as ionJs from "ion-js";
-import { Lock } from "semaphore-async-await";
+import { dom } from "ion-js";
 import * as sinon from "sinon";
 
 import { Communicator } from "../Communicator";
-import { ClientException } from "../errors/Errors";
 import { Result } from "../Result";
 import { ResultStream } from "../ResultStream";
 
@@ -97,10 +95,10 @@ describe("ResultStream", () => {
             const _readStub = sandbox.stub(resultStream as any, "_read");
             const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
             sandbox.stub(Result, "_handleBlob");
-            const makeReaderStub = sandbox.stub(ionJs as any, "makeReader");
-            makeReaderStub.onCall(0).returns(1);
-            makeReaderStub.onCall(1).returns(2);
-            makeReaderStub.returns(3);
+            const domLoadStub = sandbox.stub(dom as any, "load");
+            domLoadStub.onCall(0).returns(1);
+            domLoadStub.onCall(1).returns(2);
+            domLoadStub.returns(3);
             const pushStub = sandbox.stub(resultStream, "push");
             pushStub.returns(true);
 
@@ -120,10 +118,10 @@ describe("ResultStream", () => {
             resultStream["_cachedPage"] = testPage;
             const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
             sandbox.stub(Result, "_handleBlob");
-            const makeReaderStub = sandbox.stub(ionJs as any, "makeReader");
-            makeReaderStub.onCall(0).returns(1);
-            makeReaderStub.onCall(1).returns(2);
-            makeReaderStub.returns(3);
+            const domLoadStub = sandbox.stub(dom as any, "load");
+            domLoadStub.onCall(0).returns(1);
+            domLoadStub.onCall(1).returns(2);
+            domLoadStub.returns(3);
             const pushStub = sandbox.stub(resultStream, "push");
             pushStub.returns(true);
 
@@ -143,10 +141,10 @@ describe("ResultStream", () => {
             resultStream["_shouldPushCachedPage"] = false;
             const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
             sandbox.stub(Result, "_handleBlob");
-            const makeReaderStub = sandbox.stub(ionJs as any, "makeReader");
-            makeReaderStub.onCall(0).returns(1);
-            makeReaderStub.onCall(1).returns(2);
-            makeReaderStub.returns(3);
+            const domLoadStub = sandbox.stub(dom as any, "load");
+            domLoadStub.onCall(0).returns(1);
+            domLoadStub.onCall(1).returns(2);
+            domLoadStub.returns(3);
             const pushStub = sandbox.stub(resultStream, "push");
             pushStub.returns(true);
 
@@ -167,11 +165,11 @@ describe("ResultStream", () => {
             const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
             sandbox.stub(Result, "_handleBlob");
 
-            const makeReaderStub = sandbox.stub(ionJs as any, "makeReader");
-            makeReaderStub.onCall(0).returns(1);
-            makeReaderStub.onCall(1).returns(2);
-            makeReaderStub.onCall(2).returns(3);
-            makeReaderStub.returns(4);
+            const domLoadStub = sandbox.stub(dom as any, "load");
+            domLoadStub.onCall(0).returns(1);
+            domLoadStub.onCall(1).returns(2);
+            domLoadStub.onCall(2).returns(3);
+            domLoadStub.returns(4);
             const pushStub = sandbox.stub(resultStream, "push");
             pushStub.onCall(0).returns(true);
             pushStub.onCall(1).returns(false);
@@ -179,7 +177,7 @@ describe("ResultStream", () => {
 
             await resultStream["_pushPageValues"]();
 
-            sinon.assert.calledTwice(makeReaderStub);
+            sinon.assert.calledTwice(domLoadStub);
             sinon.assert.calledTwice(pushStub);
             sinon.assert.notCalled(_readStub);
             chai.assert.isTrue(resultStream["_shouldPushCachedPage"]);
@@ -216,10 +214,10 @@ describe("ResultStream", () => {
             const _readStub = sandbox.stub(resultStream as any, "_read");
             const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
             sandbox.stub(Result, "_handleBlob");
-            const makeReaderStub = sandbox.stub(ionJs as any, "makeReader");
-            makeReaderStub.onCall(0).returns(1);
-            makeReaderStub.onCall(1).returns(2);
-            makeReaderStub.returns(3);
+            const domLoadStub = sandbox.stub(dom as any, "load");
+            domLoadStub.onCall(0).returns(1);
+            domLoadStub.onCall(1).returns(2);
+            domLoadStub.returns(3);
             const pushStub = sandbox.stub(resultStream, "push");
             pushStub.returns(true);
 
@@ -239,8 +237,8 @@ describe("ResultStream", () => {
             const _readStub = sandbox.stub(resultStream as any, "_read");
             const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
             sandbox.stub(Result, "_handleBlob");
-            const makeReaderStub = sandbox.stub(ionJs as any, "makeReader");
-            makeReaderStub.onCall(0).returns(1);
+            const domLoadStub = sandbox.stub(dom as any, "load");
+            domLoadStub.onCall(0).returns(1);
             const pushStub = sandbox.stub(resultStream, "push");
             pushStub.returns(false);
 
@@ -256,10 +254,10 @@ describe("ResultStream", () => {
             const _readStub = sandbox.stub(resultStream as any, "_read");
             const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
             sandbox.stub(Result, "_handleBlob");
-            const makeReaderStub = sandbox.stub(ionJs as any, "makeReader");
-            makeReaderStub.onCall(0).returns(1);
-            makeReaderStub.onCall(1).returns(2);
-            makeReaderStub.returns(3);
+            const domLoadStub = sandbox.stub(dom as any, "load");
+            domLoadStub.onCall(0).returns(1);
+            domLoadStub.onCall(1).returns(2);
+            domLoadStub.returns(3);
             const pushStub = sandbox.stub(resultStream, "push");
             pushStub.returns(true);
 

--- a/src/test/TransactionExecutor.test.ts
+++ b/src/test/TransactionExecutor.test.ts
@@ -14,13 +14,12 @@
 // Test environment imports
 import "mocha";
 
-import { makeBinaryWriter, Writer } from "ion-js";
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
+import { dom, makeBinaryWriter, Writer } from "ion-js";
 import * as sinon from "sinon";
 
 import { LambdaAbortedError } from "../errors/Errors";
-import { createQldbWriter, QldbWriter } from "../QldbWriter";
 import { Result } from "../Result";
 import { ResultStream } from "../ResultStream";
 import { Transaction } from "../Transaction";
@@ -65,75 +64,72 @@ describe("TransactionExecutor", () => {
         });
     });
 
-    describe("#executeInline()", () => {
+    describe("#execute()", () => {
         it("should return a Result object when provided with a statement", async () => {
-            mockTransaction.executeInline = async () => {
+            mockTransaction.execute = async () => {
                 return mockResult;
             };
-            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeInline");
-            const result = await transactionExecutor.executeInline(testStatement);
+            const transactionExecuteSpy = sandbox.spy(mockTransaction, "execute");
+            const result = await transactionExecutor.execute(testStatement);
             chai.assert.equal(mockResult, result);
             sinon.assert.calledOnce(transactionExecuteSpy);
             sinon.assert.calledWith(transactionExecuteSpy, testStatement);
         });
 
         it("should return a Result object when provided with a statement and parameters", async () => {
-            mockTransaction.executeInline = async () => {
+            mockTransaction.execute = async () => {
                 return mockResult;
             };
-            const qldbWriter: QldbWriter = createQldbWriter();
 
-            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeInline");
-            const result = await transactionExecutor.executeInline(testStatement, [qldbWriter]);
+            const transactionExecuteSpy = sandbox.spy(mockTransaction, "execute");
+            const result = await transactionExecutor.execute(testStatement, ["a"]);
             chai.assert.equal(mockResult, result);
             sinon.assert.calledOnce(transactionExecuteSpy);
-            sinon.assert.calledWith(transactionExecuteSpy, testStatement, [qldbWriter]);
+            sinon.assert.calledWith(transactionExecuteSpy, testStatement, ["a"]);
         });
 
         it("should return a rejected promise when error is thrown", async () => {
-            mockTransaction.executeInline = async () => {
+            mockTransaction.execute = async () => {
                 throw new Error(testMessage);
             };
-            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeInline");
-            const errorMessage = await chai.expect(transactionExecutor.executeInline(testStatement)).to.be.rejected;
+            const transactionExecuteSpy = sandbox.spy(mockTransaction, "execute");
+            const errorMessage = await chai.expect(transactionExecutor.execute(testStatement)).to.be.rejected;
             chai.assert.equal(errorMessage.name, "Error");
             sinon.assert.calledOnce(transactionExecuteSpy);
             sinon.assert.calledWith(transactionExecuteSpy, testStatement);
         });
     });
 
-    describe("#executeStream()", () => {
+    describe("#executeAndStreamResults()", () => {
         it("should return a Result object when provided with a statement", async () => {
-            mockTransaction.executeStream = async () => {
+            mockTransaction.executeAndStreamResults = async () => {
                 return mockResultStream;
             };
-            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeStream");
-            const resultStream = await transactionExecutor.executeStream(testStatement);
+            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeAndStreamResults");
+            const resultStream = await transactionExecutor.executeAndStreamResults(testStatement);
             chai.assert.equal(mockResultStream, resultStream);
             sinon.assert.calledOnce(transactionExecuteSpy);
             sinon.assert.calledWith(transactionExecuteSpy, testStatement);
         });
 
         it("should return a Result object when provided with a statement and parameters", async () => {
-            mockTransaction.executeStream = async () => {
+            mockTransaction.executeAndStreamResults = async () => {
                 return mockResultStream;
             };
 
-            const qldbWriter: QldbWriter = createQldbWriter();
-
-            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeStream");
-            const resultStream = await transactionExecutor.executeStream(testStatement, [qldbWriter]);
+            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeAndStreamResults");
+            const resultStream = await transactionExecutor.executeAndStreamResults(testStatement, [5]);
             chai.assert.equal(mockResultStream, resultStream);
             sinon.assert.calledOnce(transactionExecuteSpy);
-            sinon.assert.calledWith(transactionExecuteSpy, testStatement, [qldbWriter]);
+            sinon.assert.calledWith(transactionExecuteSpy, testStatement, [5]);
         });
 
         it("should return a rejected promise when error is thrown", async () => {
-            mockTransaction.executeStream = async () => {
+            mockTransaction.executeAndStreamResults = async () => {
                 throw new Error(testMessage);
             };
-            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeStream");
-            const errorMessage = await chai.expect(transactionExecutor.executeStream(testStatement)).to.be.rejected;
+            const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeAndStreamResults");
+            const errorMessage = await chai.expect(transactionExecutor.executeAndStreamResults(testStatement)).to.be.rejected;
             chai.assert.equal(errorMessage.name, "Error");
             sinon.assert.calledOnce(transactionExecuteSpy);
             sinon.assert.calledWith(transactionExecuteSpy, testStatement);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "commonjs",
         "lib": [ "es2015" ],
         "strict": true,


### PR DESCRIPTION
Resolves #22 
Resolves #23 
Resolves #24 
Resolves #25 
Resolves #26 

This is for release v1.0.0-rc.1 which introduces [Ion DOM API support](https://github.com/amzn/ion-js/releases/tag/v4.0.0),  driver level executeLambda and varargs for transaction's execute method.
This release will also introduce breaking changes, which are documented in the CHANGELOG


## Changes in the  experience

This section does a before and after comparison of the interaction with the driver. This should also help as a guide when you upgrade your application from the previous release.

**Renaming of methods**

The [TransactionExecutor](https://github.com/awslabs/amazon-qldb-driver-nodejs/blob/master/src/TransactionExecutor.ts) had two methods `executeInline` and `executeStream` . The naming of these methods was slightly misleading and [did not convey the exact behavior of the methods](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/22). 

Hence, we have renamed the method `executeInline` to `execute` and `executeStream` to `executeAndStreamResults`. 

When the result set is large enough to not fit in the memory, `executeAndStreamResults` should be preferred, while `execute` can be used for almost all other purposes.



**Passing arguments to query**
*Before:* While passing the parameters to the parameterized query, you had to first convert the native data type into QLDBWriter type. This was unintuitive and hard to do.

```javascript
const personId =5;  
const personIdWriter  = createQldbWriter();
const personIdWriterValue = personIdWriter.writeInt(personId);
txn.execute(“SELECT name, age FROM People WHERE personId = ?”, [personIdWriterValue]);
```

*After:*  You directly pass the native data types as parameters without even having to convert to Ion Value type (although the execute method also accepts [Ion Value type](https://github.com/amzn/ion-js/releases/tag/v4.0.0))

```javascript
const personId = 5;
txn.execute(“SELECT name, age FROM People WHERE personId = ?”, personId);
```

This feature resolves  [Issue #23.](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/23)



**Support for variable arguments**

*Before:*  If there were multiple arguments to be passed to the parameterized query, then they had to be passed as a list of QldbWriters

```javascript
const name = "foo";
const age = 20;

const nameWriter = createQldbWriter();
const nameWriterValue = nameWriter.writeString();

const ageWriter = createQldbWriter();
const ageWriterValue = ageWriter.writeInt();

txn.execute("SELECT address , name, age FROM People WHERE name = ? AND age = ?", 
                [nameWriterValue, ageWriterValue]);
```


*After:* You can pass  variable number of arguments to the query as comma-separated values. Each value corresponds to a `?` in the PartiQL query.

```javascript
const name = "foo";
const age = 20;
txn.execute("SELECT address , name, age FROM People WHERE name = ? AND age = ?",
              name, age);
```

This feature resolves [Issue #24.](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/24)



**Processing query results**

*Before:* The query results were returned as a list, of type, IonReader.  You had to navigate through the reader by using methods like *stepIn(), stepOut(), next(), etc.* to obtain the fields from the result. 

```javascript
//Assume { name: "Foo" } is the first record returned by the following query;
const resultList: IonReader[] = txn.execute("SELECT name FROM People WHERE name = Foo");
const result: IonReader = resultList[0]; //Grab first record
result.next();
result.stepIn();
result.next();

const name: string = result.stringValue();
result.stepOut();
console.log("Welcome, ".concat(name)); // prints `Welcome, Foo'
```


*After:*  The results are returned as  [Ion Value type](https://github.com/amzn/ion-js/releases/tag/v4.0.0). You can simply use  `.get()` method on the result object to obtain the fields from the result. The navigation of result object becomes much more simpler.

```javascript
import { dom } from 'ion-js'

//Assume { name: "foo" } is the first  record returned by the following query;
const resultList: dom.Values[] = txn.execute("SELECT name FROM People WHERE name = Foo");

const result: dom.Value = resultList.get(0); //Grab first record

const name: String = result.get(“name”);

console.log("Welcome, ".concat(name)); //prints 'Welcome, Foo'
```

This feature resolves [Issue #25.](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/25) 



## `executeLambda` Method on Qldb Driver

*Before:* To execute a lambda against QLDB, you had to first get a session from the QLDB driver and then call the `executeLambda` method on that session instance.

```javascript
const qldbDriver: QldbDriver = new PooledQldbDriver("ledgerName", serviceConfigurationOptions);
const qldbSession: QldbSession = qldbDriver.getSession();
qldbSession.executeLambda(async (txn) => {
            txn.execute("SELECT name, age FROM People where PersonId=5");
 }, () => log("Retrying due to OCC conflict..."));
```

*After:* The `excuteLambda` method is now available on the driver itself

```javascript
const qldbDriver: QldbDriver = new PooledQldbDriver("ledgerName", serviceConfigurationOptions);
qldbDriver.executeLambda(async (txn) => {
            txn.execute("SELECT name, age FROM People where PersonId=5");
 }, () => log("Retrying due to OCC conflict..."));
```

This feature resolves [Issue #26.](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/26)




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
