### PR TITLE
Add instruction to install jsbi

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ To use the driver, in your package that wishes to use the driver, run the follow
 
 ```npm install amazon-qldb-driver-nodejs```
 
-The driver also has aws-sdk and ion-js as peer dependencies. Thus, they must also be dependencies of the package that
+The driver also has aws-sdk, ion-js and jsbi as peer dependencies. Thus, they must also be dependencies of the package that
 will be using the driver as a dependency.
 
 ```npm install aws-sdk```
 
 ```npm install ion-js```
+
+```npn install jsbi```
 
 Then from within your package, you can now use the driver by importing it. This example shows usage in TypeScript 
 specifying the QLDB ledger name and a specific region:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ will be using the driver as a dependency.
 
 ```npm install ion-js```
 
-```npn install jsbi```
+```npm install jsbi```
 
 Then from within your package, you can now use the driver by importing it. This example shows usage in TypeScript 
 specifying the QLDB ledger name and a specific region:


### PR DESCRIPTION
Resolves #28 


[Release v1.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.1) adds a peerDependency on [jsbi](https://www.npmjs.com/package/jsbi), which users will have to install manually, as noted in [Issue #28 ].

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
