### PR TITLE
[v1.0.0-rc.2] Move session pooling functionality to QldbDriver, Add `getTableNamesMethod` to driver level, and mark few methods deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 1.0.0-rc.2 (2020-05-29)
+
+## :tada: Enhancements
+
+* Session pooling functionality moved to QldbDriver.  More details can be found in the [release notes](http://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.2)
+* `getTableNames` method added at the driver level.
+
+## :bug: Fixes
+* Fixed the delay calculation logic when retrying the transaction due to failure.
+
+## :nut_and_bolt: Other
+* Added @deprecated annotation to methods which are not recommended to be used. Please see [release notes](http://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.2) for more details.
+
 # 1.0.0-rc.1 (2020-04-03)
 
 ## :boom: Breaking changes
@@ -11,11 +24,11 @@
 
 ## :tada: Enhancements
 
-* [(#5)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/5) The Ion Value results returned by `execute` and `executeAndStreamResults` can be converted into JSON String via `JSON.stringify(result)`  
+* [(#5)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/5) The Ion Value results returned by `execute` and `executeAndStreamResults` can be converted into JSON String via `JSON.stringify(result)`
 
 * [(#26)](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/26) Introduced `executeLambda` method on Qldb Driver.
 
-  
+
 
 # 0.1.2-preview.1 (2020-03-06)
 
@@ -23,7 +36,7 @@
 
 * "Error: stream.push() after EOF" bug [#7](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/7)
 * On reading from ResultStream, potential event listeners might not have received an error. Error fixed by rightly calling the destroy method and passing the error to it.
-* On starting a transaction, on consuming the resultstream, the last value could sometimes show up twice. 
+* On starting a transaction, on consuming the resultstream, the last value could sometimes show up twice.
 
 # 0.1.1-preview.2 (2019-12-26)
 
@@ -31,7 +44,7 @@
 
 * "Digests don't match" bug [#8](https://github.com/awslabs/amazon-qldb-driver-nodejs/issues/8)
 
-## :nut_and_bolt: Other​ 
+## :nut_and_bolt: Other​
 
 * Renamed src/logUtil.ts to src/LogUtil.ts to match PascalCase.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## :tada: Enhancements
 
 * Session pooling functionality moved to QldbDriver.  More details can be found in the [release notes](http://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.2)
-* `getTableNames` method added at the driver level.
 
 ## :bug: Fixes
 * Fixed the delay calculation logic when retrying the transaction due to failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@
 ## :bug: Fixes
 * Fixed the delay calculation logic when retrying the transaction due to failure.
 
-## :nut_and_bolt: Other
-* Added @deprecated annotation to methods which are not recommended to be used. Please see [release notes](http://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.2) for more details.
+## :warning: Deprecated
+
+* `PooledQldbDriver` has been deprecated and will be removed in future versions. Please use `QldbDriver` instead. Refer to the [release notes](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.2)
+
+* `QldbSession.getTableNames`  method has been deprecated and will be removed in future versions. Please use `QldbDriver.getTableNames` method instead.
+
+* `QldbSession.executeLambda`  method has been deprecated and will be removed in future versions. Please use `QldbDriver.executeLambda` method instead.
 
 # 1.0.0-rc.1 (2020-04-03)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Amazon QLDB Node.js Driver
 
-[![NPM Version](https://img.shields.io/badge/npm-v1.0.0--rc.1-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs) 
-[![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
+[![NPM Version](https://img.shields.io/badge/npm-v1.0.0--rc.2-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs)  [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
 
 This is the Node.js driver for Amazon Quantum Ledger Database (QLDB), which allows Node.js developers
 to write software that makes use of AmazonQLDB.
@@ -16,7 +15,7 @@ to write software that makes use of AmazonQLDB.
 See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developerguide/accessing.html) for information on connecting to AWS.
 
 The JavaScript AWS SDK needs to have AWS_SDK_LOAD_CONFIG environment variable set to a truthy value in order to read
-from the ~./.aws/config file.
+from the ~/.aws/config file.
 
 See [Setting Region](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html) page for more information.
 
@@ -35,8 +34,7 @@ To use the driver, in your package that wishes to use the driver, run the follow
 
 ```npm install amazon-qldb-driver-nodejs```
 
-The driver also has aws-sdk, ion-js and jsbi as peer dependencies. Thus, they must also be dependencies of the package that
-will be using the driver as a dependency.
+The driver also has aws-sdk, ion-js and jsbi as peer dependencies. Thus, they must also be dependencies of the package that will be using the driver as a dependency.
 
 ```npm install aws-sdk```
 
@@ -44,22 +42,19 @@ will be using the driver as a dependency.
 
 ```npm install jsbi```
 
-Then from within your package, you can now use the driver by importing it. This example shows usage in TypeScript 
-specifying the QLDB ledger name and a specific region:
+Then from within your package, you can now use the driver by importing it. This example shows usage in TypeScript specifying the QLDB ledger name and a specific region:
 
 ```javascript
-import { PooledQldbDriver, QldbSession } from "amazon-qldb-driver-nodejs";
+import { QldbDriver } from "amazon-qldb-driver-nodejs";
 
 const testServiceConfigOptions = {
     region: "us-east-1"
 };
 
-const qldbDriver: PooledQldbDriver = new PooledQldbDriver("testLedger", testServiceConfigOptions));
-const qldbSession: QldbSession = await qldbDriver.getSession();
-
-for (const table of await qldbSession.getTableNames()) {
-    console.log(table);
-}
+const qldbDriver: QldbDriver = new QldbDriver("testLedger", testServiceConfigOptions));
+qldbDriver.getTableNames().then(function(tableNames: string[]) {
+    console.log(tableNames);
+});
 ```
 
 ### See Also
@@ -93,6 +88,16 @@ You can run the unit tests with this command:
 or
 
 ```npm run testWithCoverage```
+
+### Integration Tests
+
+You can run the integration tests with this command:
+
+```npm run integrationTest```
+
+This command requires that credentials are pre-configured and it has the required permissions.
+
+Additionally, a region can be specified in: `src/integrationtest/.mocharc.json`.
 
 ### Documentation 
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "amazon-qldb-driver-nodejs",
   "description": "The Node.js driver for working with Amazon Quantum Ledger Database",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
@@ -29,6 +29,7 @@
     "ion-js": "~4.0.0",
     "jsbi": "~3.1.1",
     "mocha": "^6.2.0",
+    "mocha-param": "^2.0.1",
     "nyc": "^14.1.1",
     "sinon": "^7.3.2",
     "ts-node": "^8.3.0",
@@ -44,8 +45,9 @@
     "doc": "typedoc --out docs ./src --exclude **/*.test.ts",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "npm run build",
-    "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"strict\\\":false} mocha -r ts-node/register src/**/*.test.ts",
-    "testWithCoverage": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"strict\\\":false} nyc -r lcov -e .ts -x \"*.test.ts\" mocha -r ts-node/register src/**/*.test.ts && nyc report"
+    "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"strict\\\":false} mocha -r ts-node/register src/test/*.test.ts",
+    "testWithCoverage": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"strict\\\":false} nyc -r lcov -e .ts -x \"*.test.ts\" mocha -r ts-node/register src/test/*.test.ts && nyc report",
+    "integrationTest": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"strict\\\":false} mocha -r ts-node/register src/integrationtest/*.test.ts"
   },
   "author": {
     "name": "Amazon Web Services",

--- a/src/QldbDriver.ts
+++ b/src/QldbDriver.ts
@@ -13,40 +13,74 @@
 
 import { QLDBSession } from "aws-sdk";
 import { ClientConfiguration } from "aws-sdk/clients/qldbsession";
+import { globalAgent } from "http";
+import { dom } from "ion-js";
+import Semaphore from "semaphore-async-await";
 
-import { version } from "../package.json";
 import { Communicator } from "./Communicator";
-import { DriverClosedError } from "./errors/Errors";
+import { DriverClosedError, SessionPoolEmptyError } from "./errors/Errors";
 import { debug } from "./LogUtil";
+import { version } from "../package.json";
+import { PooledQldbSession } from "./PooledQldbSession";
 import { QldbSession } from "./QldbSession";
 import { QldbSessionImpl } from "./QldbSessionImpl";
+import { TransactionExecutor } from "./TransactionExecutor";
+import { Result } from "./Result";
 
 /**
- * Represents a factory for creating sessions to a specific ledger within QLDB. This class or
- * {@linkcode PooledQldbDriver} should be the main entry points to any interaction with QLDB.
- * {@linkcode QldbDriver.getSession} will create a {@linkcode QldbSession} to the specified edger within QLDB as a
- * communication channel. Any sessions acquired should be cleaned up with {@linkcode QldbSession.close} to free up
- * resources.
+ * This is the entry point for all interactions with Amazon QLDB.
  *
- * This factory does not attempt to re-use or manage sessions in any way. It is recommended to use
- * {@linkcode PooledQldbDriver} for both less resource usage and lower latency.
+ * In order to start using the driver, you need to instantiate it with a ledger name:
+ *
+ * ```
+ * let qldbDriver: QldbDriver = new QldbDriver(your-ledger-name);
+ * ```
+ * You can pass more parameters to the constructor of the driver which allow you to control certain limits
+ * to improve the performance. Check the {@link QldbDriver.constructor} to see all the available parameters.
+ *
+ * A single instance of the QldbDriver is attached to only one ledger. All transactions will be executed against
+ * the ledger specified.
+ *
+ * The driver exposes {@link QldbDriver.executeLambda}  method which should be used to execute the transactions.
+ * Check the {@link QldbDriver.executeLambda} method for more details on how to execute the Transaction.
+ *
+ * The driver also exposes {@link QldbDriver.getTableNames} method, which is a convenience method that returns the
+ * list of all the tables in the ledger.
  */
 export class QldbDriver {
     protected _qldbClient: QLDBSession;
     protected _ledgerName: string;
     protected _retryLimit: number;
     protected _isClosed: boolean;
+    private _poolLimit: number;
+    private _timeoutMillis: number;
+    private _availablePermits: number;
+    private _sessionPool: QldbSessionImpl[];
+    private _semaphore: Semaphore;
 
     /**
-     * Creates a QldbDriver.
+     * Creates a QldbDriver instance that can be used to execute transactions against Amazon QLDB. A single instance of the QldbDriver
+     * is always attached to one ledger, as specified in the ledgerName parameter.
+     *
+     * @param ledgerName The name of the ledger you want to connect to. This is a mandatory parameter.
      * @param qldbClientOptions The object containing options for configuring the low level client.
      *                          See {@link https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/QLDBSession.html#constructor-details|Low Level Client Constructor}.
-     * @param ledgerName The QLDB ledger name.
-     * @param retryLimit The number of automatic retries for statement executions using convenience methods on sessions
-                         when an OCC conflict or retriable exception occurs. This value must not be negative.
+     * @param retryLimit When there is a failure while executing the transaction like OCC or any other retriable failure, the driver will try running your transaction block again.
+     *                   This parameter tells the driver how many times to retry when there are failures. The value must be greater than 0. The default value is 4.
+     *                   See {@link https://docs.aws.amazon.com/qldb/latest/developerguide/driver.best-practices.html#driver.best-practices.configuring} for more details.
+     * @param poolLimit The driver internally uses a pool of sessions to execute the transactions. The poolLimit parameter specifies the number of sessions that the driver can hold
+     *                  in the pool. The default is set to maximum number of sockets specified in the globalAgent.
+     *                  See {@link https://docs.aws.amazon.com/qldb/latest/developerguide/driver.best-practices.html#driver.best-practices.configuring} for more details.
+     * @param timeoutMillis The number of ms the driver should wait for a session to be available in the pool before giving up. The default value is 30000.
      * @throws RangeError if `retryLimit` is less than 0.
      */
-    constructor(ledgerName: string, qldbClientOptions: ClientConfiguration = {}, retryLimit: number = 4) {
+    constructor(
+        ledgerName: string,
+        qldbClientOptions: ClientConfiguration = {},
+        retryLimit: number = 4,
+        poolLimit: number = 0,
+        timeoutMillis: number = 30000
+    ) {
         if (retryLimit < 0) {
             throw new RangeError("Value for retryLimit cannot be negative.");
         }
@@ -57,31 +91,165 @@ export class QldbDriver {
         this._ledgerName = ledgerName;
         this._retryLimit = retryLimit;
         this._isClosed = false;
+
+        if (timeoutMillis < 0) {
+            throw new RangeError("Value for timeout cannot be negative.");
+        }
+        if (poolLimit < 0) {
+            throw new RangeError("Value for poolLimit cannot be negative.");
+        }
+
+        let maxSockets: number;
+        if (qldbClientOptions.httpOptions && qldbClientOptions.httpOptions.agent) {
+            maxSockets = qldbClientOptions.httpOptions.agent.maxSockets;
+        } else {
+            maxSockets = globalAgent.maxSockets;
+        }
+
+        if (0 === poolLimit) {
+            this._poolLimit = maxSockets;
+        } else {
+            this._poolLimit = poolLimit;
+        }
+        if (this._poolLimit > maxSockets) {
+            throw new RangeError(
+                `The session pool limit given, ${this._poolLimit}, exceeds the limit set by the client,
+                 ${maxSockets}. Please lower the limit and retry.`
+            );
+        }
+
+        this._timeoutMillis = timeoutMillis;
+        this._availablePermits = this._poolLimit;
+        this._sessionPool = [];
+        this._semaphore = new Semaphore(this._poolLimit);
     }
 
     /**
-     * Close this driver.
+     * This is the primary method to execute a transaction against Amazon QLDB ledger.
+     *
+     * When this method is invoked, the driver will acquire a `Transaction` and hand it to the `TransactionExecutor` you
+     * passed via the `transactionFunction` parameter. Once the `transactionFunction`'s execution is done, the driver will try to
+     * commit the transaction.
+     * If there is a failure along the way, the driver will retry the entire transaction block. This would mean that your code inside the
+     * `transactionFunction` function should be idempotent.
+     *
+     * You can also return the results from the `transactionFunction`. Here is an example code of executing a transaction
+     *
+     * ```
+     * let result = driver.executeLambda(async (txn:TransactionExecutor) => {
+     *   let a = await txn.execute("SELECT a from Table1");
+     *   let b = await txn.execute("SELECT b from Table2");
+     *   return {a: a, b: b};
+     * });
+     *```
+     *
+     * Please keep in mind that the entire transaction will be committed once all the code inside the `transactionFunction` is executed.
+     * So for the above example the values inside the  transactionFunction, a and b, are speculative values. If the commit of the transaction fails,
+     * the entire `transactionFunction` will be retried.
+     *
+     * The function passed via retryIndicator parameter is invoked whenever there is a failure and the driver is about to retry the transaction.
+     * The retryIndicator will be called with the current attempt number.
+     *
+     * @param transactionFunction The function representing a transaction to be executed. Please see the method docs to understand the usage of this parameter.
+     * @param retryIndicator An Optional function which will be invoked when the `transactionFunction` is about to be retried due to a failure.
+     */
+    async executeLambda(
+        transactionFuntion: (transactionExecutor: TransactionExecutor) => any,
+        retryIndicator?: (retryAttempt: number) => void
+    ): Promise<any> {
+        let session: QldbSession = null;
+        try  {
+            session = await this.getSession();
+            return await session.executeLambda(transactionFuntion, retryIndicator);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+    }
+
+    /**
+     * A helper method to get all the table names in a ledger.
+     * @returns Promise which fulfills with an array of table names.
+     */
+    async getTableNames(): Promise<string[]> {
+        const statement: string = "SELECT name FROM information_schema.user_tables WHERE status = 'ACTIVE'";
+        return await this.executeLambda(async (transactionExecutor: TransactionExecutor) : Promise<string[]> => {
+            const result: Result = await transactionExecutor.execute(statement);
+            const resultStructs: dom.Value[] = result.getResultList();
+            const listOfTableNames: string[] = resultStructs.map(tableNameStruct =>
+                tableNameStruct.get("name").stringValue());
+            return listOfTableNames;
+        });
+    }
+
+    /**
+     * This is a driver shutdown method which closes all the sessions and marks the driver as closed.
+     * Once the driver is closed, no transactions can be executed on that driver instance.
+     *
+     * Note: There is no corresponding `open` method and the only option is to instantiate another driver.
      */
     close(): void {
         this._isClosed = true;
+        this._sessionPool.forEach(session => {
+            session.close();
+        });
     }
 
     /**
-     * Create and return a newly instantiated QldbSession object. This will implicitly start a new session with QLDB.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
+     * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
+     *
+     * Create and return a newly instantiated QldbSession object. This will
+     * implicitly start a new session with QLDB.
+     *
      * @returns Promise which fulfills with a QldbSession.
      * @throws {@linkcode DriverClosedError} when this driver is closed.
      */
     async getSession(): Promise<QldbSession> {
         this._throwIfClosed();
+        debug(
+            `Getting session. Current free session count: ${this._sessionPool.length}. ` +
+            `Currently available permit count: ${this._availablePermits}.`
+        );
+        const isPermitAcquired: boolean = await this._semaphore.waitFor(this._timeoutMillis);
+        if (isPermitAcquired) {
+            this._availablePermits--;
+            try {
+                while (this._sessionPool.length > 0) {
+                    const session: QldbSessionImpl = this._sessionPool.pop();
+                    const isSessionAvailable: boolean = await session._abortOrClose();
+                    if (isSessionAvailable) {
+                        debug("Reusing session from pool.")
+                        return new PooledQldbSession(session, this._returnSessionToPool);
+                    }
+                }
+                debug("Creating new pooled session.");
+                const newSession: QldbSessionImpl = <QldbSessionImpl> (await this._createSession());
+                return new PooledQldbSession(newSession, this._returnSessionToPool);
+            } catch (e) {
+                this._semaphore.release();
+                this._availablePermits++;
+                throw e;
+            }
+        }
+        throw new SessionPoolEmptyError(this._timeoutMillis)
+    }
+
+
+    private async _createSession(): Promise<QldbSession> {
         debug("Creating a new session.");
         const communicator: Communicator = await Communicator.create(this._qldbClient, this._ledgerName);
         return new QldbSessionImpl(communicator, this._retryLimit);
     }
 
-    /**
-     * Check and throw if this driver is closed.
-     * @throws {@linkcode DriverClosedError} when this driver is closed.
-     */
+    private _returnSessionToPool = (session: QldbSessionImpl): void => {
+        this._sessionPool.push(session);
+        this._semaphore.release();
+        this._availablePermits++;
+        debug(`Session returned to pool; size is now ${this._sessionPool.length}.`);
+    };
+
     protected _throwIfClosed(): void {
         if (this._isClosed) {
             throw new DriverClosedError();

--- a/src/QldbSession.ts
+++ b/src/QldbSession.ts
@@ -15,78 +15,36 @@ import { Executable } from "./Executable";
 import { Transaction } from "./Transaction";
 
 /**
- * @deprecated Use {@linkcode QldbDriver.executeLambda} instead to execute
- * transactions.
- *
- * A QldbSession is linked to the specified ledger in the parent driver of the
- * instance of the QldbSession. In any given QldbSession, only one transaction
- * can be active at a time. This object can have only one underlying session to
- * QLDB, and therefore the lifespan of a  QldbSession is tied to the underlying
- * session, which is not indefinite, and on expiry this QldbSession will become
- * invalid, and a new QldbSession needs to be created from the parent driver in
- * order to continue usage.
- *
- * See {@linkcode QldbDriver} for an example of session lifecycle management,
- * allowing the re-use of sessions when possible.
- *
- * There are three methods of execution, ranging from simple to complex; the
- * first two are recommended for inbuilt error handling:
- *  - {@linkcode QldbSession.executeStatement} allows for a single statement to
- *    be executed within a transaction where the transaction is implicitly
- *    created and committed, and any recoverable errors are transparently
- *    handled.
- *  - {@linkcode QldbSession.executeLambda} allow for more complex execution
- *    sequences where more than one execution can occur, as well as other method
- *    calls. The transaction is implicitly created and committed, and any
- *    recoverable errors are transparently handled.
- *  - {@linkcode QldbSession.startTransaction} allows for full control over when
- *    the transaction is committed and leaves the responsibility of OCC conflict
- *    handling up to the user. Transactions' methods cannot be automatically
- *    retried, as the state of the transaction is ambiguous in the case of an
- *    unexpected error.
+ * @deprecated [NOT RECOMMENDED] It is not recommended to use this class directly during transaction execution.
+ * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
  */
 export interface QldbSession extends Executable {
     
     /**
-     * Close this session. No-op if already closed.
-     * @deprecated Use {@linkcode QldbDriver} to interact with QLDB as it 
-     * manages the lifecycle of the sessions ounder the hood.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this class directly during transaction execution.
+     * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     close: () => void;
 
     /**
-     * @deprecated
-     * 
-     * Return the name of the ledger for the session.
-     * @returns Returns the name of the ledger as a string.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method.
      */
     getLedgerName: () => string;
 
     /**
-     * @deprecated Use {@linkcode QldbDriver} to interact with QLDB as it 
-     * manages the lifecycle of the sessions ounder the hood.
-     * 
-     * Returns the token for this session.
-     * @returns Returns the session token as a string.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method.
      */
     getSessionToken: () => string;
 
     /**
-     * @deprecated Use {@linkcode QldbDriver.getTableNames} instead to execute
-     * transactions.
-     * 
-     * Lists all tables in the ledger.
-     * @returns Promise which fulfills with an array of table names.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method.
+     * Instead, please use {@linkcode QldbDriver.getTableNames} to get table names.
      */
     getTableNames: () => Promise<string[]>;
 
     /**
-     * @deprecated Use {@linkcode QldbDriver.executeLambda} instead to execute
-     * transactions.
-     *
-     * Start a transaction using an available database session.
-     * @returns Promise which fulfills with a transaction object.
-     * @throws {@linkcode SessionClosedError} when the session is closed.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this class directly during transaction execution.
+     * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     startTransaction: () => Promise<Transaction>;
 }

--- a/src/QldbSession.ts
+++ b/src/QldbSession.ts
@@ -15,55 +15,75 @@ import { Executable } from "./Executable";
 import { Transaction } from "./Transaction";
 
 /**
- * The top-level interface for a QldbSession object for interacting with QLDB. A QldbSession is linked to the specified 
- * ledger in the parent driver of the instance of the QldbSession. In any given QldbSession, only one transaction can be 
- * active at a time. This object can have only one underlying session to QLDB, and therefore the lifespan of a 
- * QldbSession is tied to the underlying session, which is not indefinite, and on expiry this QldbSession will become 
- * invalid, and a new QldbSession needs to be created from the parent driver in order to continue usage.
+ * @deprecated Use {@linkcode QldbDriver.executeLambda} instead to execute
+ * transactions.
  *
- * When a QldbSession is no longer needed, {@linkcode QldbSession.close} should be invoked in order to clean up any 
- * resources.
+ * A QldbSession is linked to the specified ledger in the parent driver of the
+ * instance of the QldbSession. In any given QldbSession, only one transaction
+ * can be active at a time. This object can have only one underlying session to
+ * QLDB, and therefore the lifespan of a  QldbSession is tied to the underlying
+ * session, which is not indefinite, and on expiry this QldbSession will become
+ * invalid, and a new QldbSession needs to be created from the parent driver in
+ * order to continue usage.
  *
- * See {@linkcode PooledQldbDriver} for an example of session lifecycle management, allowing the re-use of sessions 
- * when possible.
+ * See {@linkcode QldbDriver} for an example of session lifecycle management,
+ * allowing the re-use of sessions when possible.
  *
- * There are three methods of execution, ranging from simple to complex; the first two are recommended for inbuilt 
- * error handling:
- *  - {@linkcode QldbSession.executeStatement} allows for a single statement to be executed within a transaction where 
- *    the transaction is implicitly created and committed, and any recoverable errors are transparently handled.
- *  - {@linkcode QldbSession.executeLambda} allow for more complex execution sequences where more than one execution can 
- *    occur, as well as other method calls. The transaction is implicitly created and committed, and any recoverable 
- *    errors are transparently handled.
- *  - {@linkcode QldbSession.startTransaction} allows for full control over when the transaction is committed and 
- *    leaves the responsibility of OCC conflict handling up to the user. Transactions' methods cannot be automatically 
- *    retried, as the state of the transaction is ambiguous in the case of an unexpected error.
+ * There are three methods of execution, ranging from simple to complex; the
+ * first two are recommended for inbuilt error handling:
+ *  - {@linkcode QldbSession.executeStatement} allows for a single statement to
+ *    be executed within a transaction where the transaction is implicitly
+ *    created and committed, and any recoverable errors are transparently
+ *    handled.
+ *  - {@linkcode QldbSession.executeLambda} allow for more complex execution
+ *    sequences where more than one execution can occur, as well as other method
+ *    calls. The transaction is implicitly created and committed, and any
+ *    recoverable errors are transparently handled.
+ *  - {@linkcode QldbSession.startTransaction} allows for full control over when
+ *    the transaction is committed and leaves the responsibility of OCC conflict
+ *    handling up to the user. Transactions' methods cannot be automatically
+ *    retried, as the state of the transaction is ambiguous in the case of an
+ *    unexpected error.
  */
 export interface QldbSession extends Executable {
     
     /**
      * Close this session. No-op if already closed.
+     * @deprecated Use {@linkcode QldbDriver} to interact with QLDB as it 
+     * manages the lifecycle of the sessions ounder the hood.
      */
     close: () => void;
 
     /**
+     * @deprecated
+     * 
      * Return the name of the ledger for the session.
      * @returns Returns the name of the ledger as a string.
      */
     getLedgerName: () => string;
 
     /**
+     * @deprecated Use {@linkcode QldbDriver} to interact with QLDB as it 
+     * manages the lifecycle of the sessions ounder the hood.
+     * 
      * Returns the token for this session.
      * @returns Returns the session token as a string.
      */
     getSessionToken: () => string;
 
     /**
+     * @deprecated Use {@linkcode QldbDriver.getTableNames} instead to execute
+     * transactions.
+     * 
      * Lists all tables in the ledger.
      * @returns Promise which fulfills with an array of table names.
      */
     getTableNames: () => Promise<string[]>;
 
     /**
+     * @deprecated Use {@linkcode QldbDriver.executeLambda} instead to execute
+     * transactions.
+     *
      * Start a transaction using an available database session.
      * @returns Promise which fulfills with a transaction object.
      * @throws {@linkcode SessionClosedError} when the session is closed.

--- a/src/QldbSessionImpl.ts
+++ b/src/QldbSessionImpl.ts
@@ -33,7 +33,7 @@ const SLEEP_CAP_MS: number = 5000;
 const SLEEP_BASE_MS: number = 10;
 
 /**
- * @deprecated [NOT RECOMMENDED} It is not recommended to use this class directly during transaction execution.
+ * @deprecated [NOT RECOMMENDED] It is not recommended to use this class directly during transaction execution.
  * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
  */
 export class QldbSessionImpl implements QldbSession {
@@ -48,7 +48,7 @@ export class QldbSessionImpl implements QldbSession {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     close(): void {
@@ -60,7 +60,7 @@ export class QldbSessionImpl implements QldbSession {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     async executeLambda(
@@ -117,7 +117,7 @@ export class QldbSessionImpl implements QldbSession {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method.
      * Instead, please use {@linkcode QldbDriver.getTableNames} to get table names.
      */
     async getTableNames(): Promise<string[]> {
@@ -132,7 +132,7 @@ export class QldbSessionImpl implements QldbSession {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     async startTransaction(): Promise<Transaction> {
@@ -146,7 +146,7 @@ export class QldbSessionImpl implements QldbSession {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     async _abortOrClose(): Promise<boolean> {

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -45,7 +45,7 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     async abort(): Promise<void> {
@@ -57,7 +57,7 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     async commit(): Promise<void> {
@@ -94,7 +94,7 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-      * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+      * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
       * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
       *
       * Execute the specified statement in the current transaction. This method
@@ -119,7 +119,7 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      *
      * @param statement A statement to execute against QLDB as a string.
@@ -137,7 +137,7 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-      * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+      * @deprecated [NOT RECOMMENDED] It is not recommended to use this method during transaction execution.
       * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
       *
       * Retrieve the transaction ID associated with this transaction.

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -25,22 +25,9 @@ import { ResultStream } from "./ResultStream";
 import { TransactionExecutable } from "./TransactionExecutable";
 
 /**
- * A class representing a QLDB transaction.
+ * @deprecated Use {@linkcode QldbDriver.executeLambda} instead to execute
+ * transactions.
  *
- * Every transaction is tied to a parent (Pooled)QldbSession, meaning that if the parent session is closed or
- * invalidated, the child transaction is automatically closed and cannot be used. Only one transaction can be active at
- * any given time per parent session, and thus every transaction should call {@linkcode Transaction.abort} or
- * {@linkcode Transaction.commit} when it is no longer needed, or when a new transaction is desired from the parent
- * session.
- *
- * An InvalidSessionException indicates that the parent session is dead, and a new transaction cannot be created
- * without a new (Pooled)QldbSession being created from the parent driver.
- *
- * Any unexpected errors that occur within a transaction should not be retried using the same transaction, as the state
- * of the transaction is now ambiguous.
- *
- * When an OCC conflict occurs, the transaction is closed and must be handled manually by creating a new transaction
- * and re-executing the desired queries.
  */
 export class Transaction implements TransactionExecutable {
     private _communicator: Communicator;
@@ -49,11 +36,6 @@ export class Transaction implements TransactionExecutable {
     private _txnHash: QldbHash;
     private _hashLock: Lock;
 
-    /**
-     * Create a Transaction.
-     * @param communicator The Communicator object representing a communication channel with QLDB.
-     * @param txnId The ID of the transaction.
-     */
     constructor(communicator: Communicator, txnId: string) {
         this._communicator = communicator;
         this._txnId = txnId;
@@ -63,8 +45,8 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * Abort this transaction and close child ResultStream objects. No-op if already closed by commit or previous abort.
-     * @returns Promise which fulfills with void.
+     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     async abort(): Promise<void> {
         if (this._isClosed) {
@@ -75,10 +57,8 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * Commits and closes child ResultStream objects.
-     * @returns Promise which fulfills with void.
-     * @throws {@linkcode TransactionClosedError} when this transaction is closed.
-     * @throws {@linkcode ClientException} when the commit digest from commit transaction result does not match.
+     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      */
     async commit(): Promise<void> {
         if (this._isClosed) {
@@ -114,16 +94,23 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * Execute the specified statement in the current transaction. This method returns a promise
-     * which eventually returns all the results loaded into memory.
-     *
-     * @param statement A statement to execute against QLDB as a string.
-     * @param parameters Variable number of arguments, where each argument corresponds to a
-     *                  placeholder (?) in the PartiQL query.
-     *                  The argument could be any native JavaScript type or an Ion DOM type.
-     *                  [Details of Ion DOM type and JavaScript type](https://github.com/amzn/ion-js/blob/master/src/dom/README.md#iondom-data-types)
-     * @returns Promise which fulfills with all results loaded into memory
-     * @throws [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) when the passed argument value cannot be converted into Ion
+      * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
+      *
+      * Execute the specified statement in the current transaction. This method
+      * returns a promise which eventually returns all the results loaded into
+      * memory.
+      *
+      * @param statement A statement to execute against QLDB as a string.
+      * @param parameters Variable number of arguments, where each argument
+      *                 corresponds to a placeholder (?) in the PartiQL query.
+      *                 The argument could be any native JavaScript type or an
+      *                 Ion DOM type. [Details of Ion DOM type and JavaScript
+      *                 type](https://github.com/amzn/ion-js/blob/master/src/dom/README.md#iondom-data-types)
+      * @returns Promise which fulfills with all results loaded into memory
+      * @throws
+      * [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
+      * when the passed argument value cannot be converted into Ion
      */
     async execute(statement: string, ...parameters: any[]): Promise<Result> {
         const result: ExecuteStatementResult = await this._sendExecute(statement, parameters);
@@ -132,8 +119,8 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * Execute the specified statement in the current transaction. This method returns a promise
-     * which fulfills with Readable Stream, which allows you to stream one record at time
+     * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+     * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
      *
      * @param statement A statement to execute against QLDB as a string.
      * @param parameters Variable number of arguments, where each argument corresponds to a
@@ -150,28 +137,20 @@ export class Transaction implements TransactionExecutable {
     }
 
     /**
-     * Retrieve the transaction ID associated with this transaction.
-     * @returns The transaction ID.
+      * @deprecated [NOT RECOMMENDED} It is not recommended to use this method during transaction execution.
+      * Instead, please use {@linkcode QldbDriver.executeLambda} to execute the transaction.
+      *
+      * Retrieve the transaction ID associated with this transaction.
+      * @returns The transaction ID.
      */
     getTransactionId(): string {
         return this._txnId;
     }
 
-    /**
-     * Mark the transaction as closed.
-     */
     private _internalClose(): void {
         this._isClosed = true;
     }
 
-    /**
-     * Helper method to execute statement against QLDB.
-     * @param statement A statement to execute against QLDB as a string.
-     * @param parameters An optional list of Ion values or JavaScript native types that are convertible to Ion for
-     *                   filling in parameters of the statement.
-     * @returns Promise which fulfills with a ExecuteStatementResult object.
-     * @throws {@linkcode TransactionClosedError} when transaction is closed.
-     */
     private async _sendExecute(statement: string, parameters: any[]): Promise<ExecuteStatementResult> {
         if (this._isClosed) {
             throw new TransactionClosedError();

--- a/src/TransactionExecutor.ts
+++ b/src/TransactionExecutor.ts
@@ -44,6 +44,10 @@ export class TransactionExecutor implements TransactionExecutable {
      * Execute the specified statement in the current transaction. This method returns a promise
      * which eventually returns all the results loaded into memory.
      *
+     * The PartiQL statement executed via this transaction is not immediately committed.
+     * The entire transaction will be committed once the all the code in `transactionFunction`
+     * (passed as an argument to {@link QldbDriver.executeLambda}) completes.
+     *
      * @param statement The statement to execute.
      * @param parameters Variable number of arguments, where each argument corresponds to a
      *                  placeholder (?) in the PartiQL query.
@@ -59,6 +63,10 @@ export class TransactionExecutor implements TransactionExecutable {
     /**
      * Execute the specified statement in the current transaction. This method returns a promise
      * which fulfills with Readable interface, which allows you to stream one record at time
+     *
+     * The PartiQL statement executed via this transaction is not immediately committed.
+     * The entire transaction will be committed once the all the code in `transactionFunction`
+     * (passed as an argument to {@link QldbDriver.executeLambda}) completes.
      *
      * @param statement The statement to execute.
      * @param parameters Variable number of arguments, where each argument corresponds to a

--- a/src/integrationtest/.mocharc.json
+++ b/src/integrationtest/.mocharc.json
@@ -1,0 +1,3 @@
+{
+    "region": "us-east-1"
+}

--- a/src/integrationtest/SessionManagement.test.ts
+++ b/src/integrationtest/SessionManagement.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { AWSError } from "aws-sdk";
+import { ClientConfiguration } from "aws-sdk/clients/qldbsession";
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import { dom } from "ion-js";
+
+import { SessionPoolEmptyError, DriverClosedError } from "../errors/Errors";
+import { QldbDriver } from "../QldbDriver";
+import { Result } from "../Result";
+import { TransactionExecutor } from "../TransactionExecutor";
+import * as constants from "./TestConstants";
+import { TestUtils } from "./TestUtils";
+
+chai.use(chaiAsPromised);
+
+describe("SessionManagement", function() {
+    this.timeout(0);
+    let testUtils: TestUtils;
+    let config: ClientConfiguration; 
+
+    before(async () => {
+        testUtils = new TestUtils(constants.LEDGER_NAME);
+        config = testUtils.createClientConfiguration();
+
+        await testUtils.runForceDeleteLedger();
+        await testUtils.runCreateLedger();
+
+        // Create table
+        const driver: QldbDriver = new QldbDriver(constants.LEDGER_NAME, config);
+        const statement: string = `CREATE TABLE ${constants.TABLE_NAME}`;
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor): Promise<number> => {
+            const result: Result = await txn.execute(statement);
+            const resultSet: dom.Value[] = result.getResultList();
+            return resultSet.length;
+        });
+        chai.assert.equal(count, 1);
+        await new Promise(r => setTimeout(r, 3000));
+    });
+
+    after(async () => {
+        await testUtils.runDeleteLedger();
+    });
+
+    it("Throws exception when connecting to a non-existent ledger", async () => {
+        const driver: QldbDriver = new QldbDriver("NonExistentLedger", config);
+        let error: AWSError;
+        try {
+            error = await chai.expect(driver.executeLambda(async (txn: TransactionExecutor) => {
+                await txn.execute(`SELECT name FROM ${constants.TABLE_NAME} WHERE name='Bob'`);
+            })).to.be.rejected;
+
+        } finally {
+            chai.assert.equal(error.code, "BadRequestException");
+            driver.close();
+        }
+    });
+
+    it("Can get a session when the pool has no sessions and hasn't hit the pool limit", async () => {
+        // Start a pooled driver with default pool limit so it doesn't have sessions in the pool
+        // and has not hit the limit
+        const driver: QldbDriver = new QldbDriver(constants.LEDGER_NAME, config);
+        try {
+            // Execute a statement to implicitly create a session and return it to the pool
+            await driver.executeLambda(async (txn: TransactionExecutor) => {
+                await txn.execute(`SELECT name FROM ${constants.TABLE_NAME} WHERE name='Bob'`);
+            });
+        } finally {
+            driver.close();
+        }
+    });
+
+    it("Throws exception when all the sessions are busy, pool limit is reached, and timeout is exceeded", async () => {
+        // Set the timeout to 1ms and pool limit to 1
+        const driver: QldbDriver = new  QldbDriver(constants.LEDGER_NAME, config, undefined, 1, 1);
+        try {
+            // Execute and do not wait for the promise to resolve, exhausting the pool
+            driver.executeLambda(async (txn: TransactionExecutor) => {
+                await txn.execute(`SELECT name FROM ${constants.TABLE_NAME} WHERE name='Bob'`);
+            });
+            // Attempt to implicitly get a session by executing
+            await driver.executeLambda(async (txn: TransactionExecutor) => {
+                await txn.execute(`SELECT name FROM ${constants.TABLE_NAME} WHERE name='Bob'`);
+            });
+            chai.assert.fail("SessionPoolEmptyError was not thrown")
+        } catch (e) {
+            if (!(e instanceof SessionPoolEmptyError)) {
+                throw e;
+            }
+        } finally {
+            driver.close();
+        }
+    });
+
+    it("Can get a session when the pool has no sessions, pool limit is reached, but a session is returned within the timeout", async () => {
+        // Set the timeout to 30000ms and pool limit to 1
+        const driver: QldbDriver = new  QldbDriver(constants.LEDGER_NAME, config, undefined, 1, 30000);
+        try {
+            // Execute and do not wait for the promise to resolve, exhausting the pool
+            await driver.executeLambda(async (txn: TransactionExecutor) => {
+                await txn.execute(`SELECT name FROM ${constants.TABLE_NAME} WHERE name='Bob'`);
+            });
+            // Attempt to implicitly get a session by executing, waiting for up to 30000ms
+            await driver.executeLambda(async (txn: TransactionExecutor) => {
+                await txn.execute(`SELECT name FROM ${constants.TABLE_NAME} WHERE name='Bob'`);
+            });
+        } finally {
+            driver.close();
+        }
+    });
+
+    it("Throws exception when the driver has been closed", async () => {
+        const driver: QldbDriver = new QldbDriver(constants.LEDGER_NAME, config);
+        driver.close();
+        try {
+            await driver.executeLambda(async (txn: TransactionExecutor) => {
+                await txn.execute(`SELECT name FROM ${constants.TABLE_NAME} WHERE name='Bob'`);
+            });
+        } catch (e) {
+            if (!(e instanceof DriverClosedError)) {
+                throw e;
+            }
+        }
+    });
+});

--- a/src/integrationtest/StatementExecution.test.ts
+++ b/src/integrationtest/StatementExecution.test.ts
@@ -1,0 +1,390 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { AWSError } from "aws-sdk";
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import { dom, IonType } from "ion-js";
+
+import { isOccConflictException } from "../errors/Errors";
+import { QldbDriver } from "../QldbDriver";
+import { Result } from "../Result";
+import { TransactionExecutor } from "../TransactionExecutor";
+import * as constants from "./TestConstants";
+import { TestUtils } from "./TestUtils";
+
+const itParam = require("mocha-param");
+chai.use(chaiAsPromised);
+
+describe("StatementExecution", function() {
+    this.timeout(0);
+    let testUtils: TestUtils; 
+    let driver: QldbDriver;
+
+    before(async () => {
+        testUtils = new TestUtils(constants.LEDGER_NAME);
+
+        await testUtils.runForceDeleteLedger();
+        await testUtils.runCreateLedger();
+
+        driver = new QldbDriver(constants.LEDGER_NAME, testUtils.createClientConfiguration());
+
+        // Create table
+        const statement: string = `CREATE TABLE ${constants.TABLE_NAME}`;
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor): Promise<number> => {
+            const result: Result = await txn.execute(statement);
+            const resultSet: dom.Value[] = result.getResultList();
+            return resultSet.length;
+        });
+        chai.assert.equal(count, 1);
+    });
+
+    after(async () => {
+        await testUtils.runDeleteLedger();
+        driver.close();
+    });
+
+    this.afterEach(async () => {
+        await driver.executeLambda(async (txn: TransactionExecutor) => {
+            await txn.execute(`DELETE FROM ${constants.TABLE_NAME}`);
+        });
+    });
+
+    it("Can create and drop a table", async () => {
+        // Create table
+        const createTableStatement: string = `CREATE TABLE ${constants.CREATE_TABLE_NAME}`;
+        const createTableCount: number = await driver.executeLambda(async (txn: TransactionExecutor): Promise<number> => {
+            const result: Result = await txn.execute(createTableStatement);
+            const resultSet: dom.Value[] = result.getResultList();
+            return resultSet.length;
+        });
+        chai.assert.equal(createTableCount, 1); 
+
+        // List tables in ledger to ensure table is created
+        const firstListTablesResult: string[] = await driver.getTableNames()
+        chai.assert.isTrue(firstListTablesResult.includes(constants.CREATE_TABLE_NAME));
+
+        // Drop table
+        const dropTableStatement: string = `DROP TABLE ${constants.CREATE_TABLE_NAME}`;
+        const dropTableCount: number = await driver.executeLambda(async (txn: TransactionExecutor): Promise<number> => {
+            const result: Result = await txn.execute(dropTableStatement);
+            const resultSet: dom.Value[] = result.getResultList();
+            return resultSet.length;
+        });
+        chai.assert.equal(dropTableCount, 1); 
+
+        // List tables in ledger to ensure table is dropped
+        const secondListTablesResult: string[] = await driver.getTableNames()
+        chai.assert.isFalse(secondListTablesResult.includes(constants.CREATE_TABLE_NAME));
+    });
+
+    it("Can return a list of table names", async () => {
+        const tables: string[] = await driver.getTableNames();
+        chai.assert.equal(tables[0], constants.TABLE_NAME);
+    });
+
+    it("Throws exception when creating table using the same name as an already-existing one", async () => {
+        const statement: string = `CREATE TABLE ${constants.TABLE_NAME}`;
+        const error: AWSError = await chai.expect(driver.executeLambda(async (txn: TransactionExecutor) => {
+            await txn.execute(statement);
+        })).to.be.rejected;
+        chai.assert.equal(error.code, "BadRequestException");
+    });
+
+    it("Can create an index", async () => {
+        const createIndexStatement: string = `CREATE INDEX on ${constants.TABLE_NAME} (${constants.INDEX_ATTRIBUTE})`;
+
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            const result: Result = await txn.execute(createIndexStatement);
+            return result.getResultList().length;
+        });
+        chai.assert.equal(count, 1);
+
+        const searchStatement = `SELECT VALUE indexes[0] FROM information_schema.user_tables WHERE status = 'ACTIVE'` +
+            `AND name = '${constants.TABLE_NAME}'`;
+        const indexColumn: string = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            const result: Result = await txn.execute(searchStatement);
+            // This gives:
+            // {
+            //    expr: "[MyColumn]"
+            // }
+            const indexColumn: string = result.getResultList()[0].elements()[0].stringValue();
+            return indexColumn;
+        });
+        chai.assert.equal(indexColumn, "[" + constants.INDEX_ATTRIBUTE + "]");
+    });
+
+    it("Returns an empty result when querying table with no records", async () => {
+        const statement: string = `SELECT * FROM ${constants.TABLE_NAME}`;
+        const results: dom.Value[] = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(statement)).getResultList();
+        });
+        chai.assert.equal(results.length, 0);
+    });
+
+    it("Can insert a document", async () => {
+        const struct: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.SINGLE_DOCUMENT_VALUE
+        };
+        const insertStatement: string = `INSERT INTO ${constants.TABLE_NAME} ?`;
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(insertStatement, struct)).getResultList().length;
+        });
+        chai.assert.equal(count, 1);
+
+        const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM ${constants.TABLE_NAME} WHERE ` +
+            `${constants.COLUMN_NAME} = ?`;
+        const value: string = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(searchQuery, constants.SINGLE_DOCUMENT_VALUE)).getResultList()[0].stringValue();
+        });
+        chai.assert.equal(value, constants.SINGLE_DOCUMENT_VALUE);
+    });
+
+    it("Can query a table enclosed in quotes", async () => {
+        const struct: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.SINGLE_DOCUMENT_VALUE
+        };
+        const insertStatement: string = `INSERT INTO ${constants.TABLE_NAME} ?`;
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(insertStatement, struct)).getResultList().length;
+        });
+        chai.assert.equal(count, 1);
+            
+        const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM "${constants.TABLE_NAME}" WHERE ` +
+            `${constants.COLUMN_NAME} = ?`;
+        const value: string = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(searchQuery, constants.SINGLE_DOCUMENT_VALUE)).getResultList()[0].stringValue();
+        });
+        chai.assert.equal(value, constants.SINGLE_DOCUMENT_VALUE);
+    });
+
+    it("Can insert multiple documents", async () => {
+        const struct1: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.MULTI_DOC_VALUE_1
+        };
+        const struct2: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.MULTI_DOC_VALUE_2
+        };
+        const insertStatement: string = `INSERT INTO ${constants.TABLE_NAME} <<?,?>>`;
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(insertStatement, struct1, struct2)).getResultList().length;
+        });
+        chai.assert.equal(count, 2);
+
+        const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM ${constants.TABLE_NAME} WHERE ` + 
+            `${constants.COLUMN_NAME} IN (?,?)`;
+        const tables: string[] = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            const result: Result = await txn.execute(searchQuery, constants.MULTI_DOC_VALUE_1, constants.MULTI_DOC_VALUE_2);
+            const resultSet: dom.Value[] = result.getResultList();
+            return resultSet.map((value: dom.Value) => {
+                return value.stringValue();
+            });
+        });
+        chai.assert.isTrue(tables.includes(constants.MULTI_DOC_VALUE_1));
+        chai.assert.isTrue(tables.includes(constants.MULTI_DOC_VALUE_2));
+    });
+    
+    it("Can delete a single document", async () => {
+        const struct: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.SINGLE_DOCUMENT_VALUE
+        };
+        const insertStatement: string = `INSERT INTO ${constants.TABLE_NAME} ?`;
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(insertStatement, struct)).getResultList().length;
+        });
+        chai.assert.equal(count, 1);
+
+        const deleteStatement: string = `DELETE FROM ${constants.TABLE_NAME} WHERE ${constants.COLUMN_NAME} = ?`;
+        const deleteCount: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(deleteStatement, constants.SINGLE_DOCUMENT_VALUE)).getResultList().length;
+        });
+        chai.assert.equal(deleteCount, 1);
+
+        const searchQuery: string = `SELECT COUNT(*) FROM ${constants.TABLE_NAME}`;
+        const searchCount: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            // This gives:
+            // {
+            //    _1: 1
+            // }
+            return (await txn.execute(searchQuery)).getResultList()[0].elements()[0].numberValue();
+        });
+
+        chai.assert.equal(searchCount, 0);
+    });
+
+    it("Can delete all documents", async () => {
+        const struct1: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.MULTI_DOC_VALUE_1
+        };
+        const struct2: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.MULTI_DOC_VALUE_2
+        };
+        const insertStatement: string = `INSERT INTO ${constants.TABLE_NAME} <<?,?>>`;
+        const count: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(insertStatement, struct1, struct2)).getResultList().length;
+        });
+        chai.assert.equal(count, 2);
+
+        const deleteStatement: string = `DELETE FROM ${constants.TABLE_NAME}`;
+        const deleteCount: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(deleteStatement)).getResultList().length;
+        });
+        chai.assert.equal(deleteCount, 2);
+
+        const searchQuery: string = `SELECT COUNT(*) FROM ${constants.TABLE_NAME}`;
+        const searchCount: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            // This gives:
+            // {
+            //    _1: 1
+            // }
+            return (await txn.execute(searchQuery)).getResultList()[0].elements()[0].numberValue();
+        });
+        chai.assert.equal(searchCount, 0);
+    });
+
+    it("Throws OCC error if the same record is updated at the same time", async () => {
+        const struct: Record<string, number> = {
+            [constants.COLUMN_NAME]: 0
+        };
+
+        const result: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(`INSERT INTO ${constants.TABLE_NAME} ?`, struct)).getResultList().length;
+        });
+        chai.assert.equal(result, 1);
+        
+        // Create a driver that does not retry OCC errors
+        const noRetryDriver: QldbDriver = new QldbDriver(constants.LEDGER_NAME, testUtils.createClientConfiguration(), 0);
+        async function updateField(driver: QldbDriver): Promise<void> {
+            await driver.executeLambda(async (txn: TransactionExecutor) => {
+                let currentValue: number;
+                
+                // Query table
+                const result: Result = await txn.execute(`SELECT VALUE ${constants.COLUMN_NAME} from ${constants.TABLE_NAME}`);
+                currentValue = result.getResultList()[0].numberValue();
+
+                // Update document
+                await txn.execute(`UPDATE ${constants.TABLE_NAME} SET ${constants.COLUMN_NAME} = ?`, currentValue + 5);
+            });
+        }
+
+        let occFlag: boolean = false;
+        try {   
+            await Promise.all([updateField(noRetryDriver), updateField(noRetryDriver), updateField(noRetryDriver)]);
+        } catch (e) {
+            if (isOccConflictException(e)) {
+                occFlag = true;
+            }
+        }
+        chai.assert.isTrue(occFlag);
+    });
+
+    itParam("Can insert and read different Ion types", TestUtils.getIonTypes(), async (value: dom.Value) => {
+        // Insert the Ion Value
+        const struct: Record<string, dom.Value> = {
+            [constants.COLUMN_NAME]: value
+        };
+
+        const result: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(`INSERT INTO ${constants.TABLE_NAME} ?`, struct)).getResultList().length;
+        });
+        chai.assert.equal(result, 1);
+
+        // Read the Ion Value
+        if (value.isNull()) {
+            const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM ${constants.TABLE_NAME}` + 
+                ` WHERE ${constants.COLUMN_NAME} IS NULL`;
+            const returnedValue: IonType = await driver.executeLambda(async (txn: TransactionExecutor) => {
+                const result: Result = await txn.execute(searchQuery);
+                const resultSet: dom.Value[] = result.getResultList();
+                return resultSet[0].getType();
+            });
+            chai.assert.equal(returnedValue, value.getType());
+
+        } else {
+            const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM ${constants.TABLE_NAME}` + 
+            ` WHERE ${constants.COLUMN_NAME} = ?`;
+            const returnedValue: IonType = await driver.executeLambda(async (txn: TransactionExecutor) => {
+                const result: Result = await txn.execute(searchQuery, value);
+                const resultSet: dom.Value[] = result.getResultList();
+                return resultSet[0].getType();
+            });
+            chai.assert.equal(returnedValue, value.getType());
+        }
+    });
+
+    itParam("Can update different Ion types", TestUtils.getIonTypes(), async (value: dom.Value) => {
+        // Insert a base Ion Value
+        const struct: Record<string, dom.Value> = {
+            [constants.COLUMN_NAME]: dom.load("null")
+        };
+
+        const result: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(`INSERT INTO ${constants.TABLE_NAME} ?`, struct)).getResultList().length;
+        });
+        chai.assert.equal(result, 1);
+
+        // Update the Ion Value
+        const updateQuery: string = `UPDATE ${constants.TABLE_NAME} SET ${constants.COLUMN_NAME} = ?`;
+        const updateResult: number = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(updateQuery, value)).getResultList().length;
+        });
+        chai.assert.equal(updateResult, 1);
+        
+        // Read the Ion Value
+        if (value.isNull()) {
+            const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM ${constants.TABLE_NAME}` + 
+                ` WHERE ${constants.COLUMN_NAME} IS NULL`;
+            const returnedValue: IonType = await driver.executeLambda(async (txn: TransactionExecutor) => {
+                const result: Result = await txn.execute(searchQuery);
+                const resultSet: dom.Value[] = result.getResultList();
+                return resultSet[0].getType();
+            });
+            chai.assert.equal(returnedValue, value.getType());
+
+        } else {
+            const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM ${constants.TABLE_NAME}` + 
+                ` WHERE ${constants.COLUMN_NAME} = ?`;
+            const returnedValue: IonType = await driver.executeLambda(async (txn: TransactionExecutor) => {
+                const result: Result = await txn.execute(searchQuery, value);
+                const resultSet: dom.Value[] = result.getResultList();
+                return resultSet[0].getType();
+            });
+            chai.assert.equal(returnedValue, value.getType());
+        }
+    });
+
+    it("Statements are executed without needing a returned value", async () => {
+        const struct: Record<string, string> = {
+            [constants.COLUMN_NAME]: constants.SINGLE_DOCUMENT_VALUE
+        };
+        const insertStatement: string = `INSERT INTO ${constants.TABLE_NAME} ?`;
+        await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(insertStatement, struct)).getResultList().length;
+        });
+
+        const searchQuery: string = `SELECT VALUE ${constants.COLUMN_NAME} FROM ${constants.TABLE_NAME} WHERE ` + 
+            `${constants.COLUMN_NAME} = ?`;
+        const value: string = await driver.executeLambda(async (txn: TransactionExecutor) => {
+            return (await txn.execute(searchQuery, constants.SINGLE_DOCUMENT_VALUE)).getResultList()[0].stringValue();
+        });
+        chai.assert.equal(value, constants.SINGLE_DOCUMENT_VALUE);
+    });
+
+    it("Throws exception when deleting from a table that doesn't exist", async () => {
+        const statement: string = "DELETE FROM NonExistentTable";
+        const error: AWSError = await chai.expect(driver.executeLambda(async (txn: TransactionExecutor) => {
+            await txn.execute(statement);
+        })).to.be.rejected;
+        chai.assert.equal(error.code, "BadRequestException");
+    });
+});

--- a/src/integrationtest/TestConstants.ts
+++ b/src/integrationtest/TestConstants.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+export const TABLE_NAME = "NodeTestTable";
+export const CREATE_TABLE_NAME = "NodeCreateTestTable";
+export const INDEX_ATTRIBUTE = "Name";
+export const COLUMN_NAME = "Name";
+export const SINGLE_DOCUMENT_VALUE = "SingleDocumentValue";
+export const MULTI_DOC_VALUE_1 = "MultipleDocumentValue1";
+export const MULTI_DOC_VALUE_2 = "MultipleDocumentValue2";
+export const LEDGER_NAME = "Node-TestLedger";

--- a/src/integrationtest/TestUtils.ts
+++ b/src/integrationtest/TestUtils.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { QLDB } from "aws-sdk";
+import { ClientConfiguration } from "aws-sdk/clients/qldbsession";
+import {
+    CreateLedgerRequest,
+    CreateLedgerResponse,
+    DeleteLedgerRequest,
+    DescribeLedgerRequest,
+    DescribeLedgerResponse,
+    UpdateLedgerRequest
+} from "aws-sdk/clients/qldb";
+import { dom, load } from "ion-js";
+
+import * as mocharc from './.mocharc.json'
+import { isResourceNotFoundException } from "../errors/Errors";
+
+export class TestUtils {
+    public ledgerName: string;
+    public regionName: string;
+    public clientConfig: ClientConfiguration;
+    public qldbClient: QLDB;
+
+    constructor(ledgerName: string) {
+        this.ledgerName = ledgerName;
+        this.regionName = mocharc.region;
+        this.clientConfig = this.createClientConfiguration();
+        this.qldbClient = new QLDB(this.clientConfig);
+    }
+    
+    createClientConfiguration() : ClientConfiguration {
+        const config: ClientConfiguration = {};
+        if (this.regionName != undefined) {
+            config.region = this.regionName;
+        }
+        return config;
+    }
+
+    static sleep(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    async runCreateLedger(): Promise<void> {
+        console.log(`Creating a ledger named: ${this.ledgerName}...`);
+        const request: CreateLedgerRequest = {
+            Name: this.ledgerName,
+            PermissionsMode: "ALLOW_ALL"
+        }
+        const response: CreateLedgerResponse = await this.qldbClient.createLedger(request).promise();
+        console.log(`Success. Ledger state: ${response.State}.`);
+        await this.waitForActive();
+    }
+
+    async waitForActive(): Promise<void> {
+        console.log(`Waiting for ledger ${this.ledgerName} to become active...`);
+        const request: DescribeLedgerRequest = {
+            Name: this.ledgerName
+        }
+        while (true) {
+            const result: DescribeLedgerResponse = await this.qldbClient.describeLedger(request).promise();
+            if (result.State === "ACTIVE") {
+                console.log("Success. Ledger is active and ready to be used.");
+                return;
+            }
+            console.log("The ledger is still creating. Please wait...");
+            await TestUtils.sleep(10000);
+        }
+    }
+
+    async runDeleteLedger(): Promise<void> {
+        await this.deleteLedger();
+        await this.waitForDeletion();
+    }
+
+    async runForceDeleteLedger(): Promise<void> {
+        try {
+            await this.deleteLedger();
+            await this.waitForDeletion();
+        } catch (e) {
+            if (isResourceNotFoundException(e)) {
+                console.log("Ledger did not previously exist.");
+                return;
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private async deleteLedger(): Promise<void> {
+        console.log(`Attempting to delete the ledger with name: ${this.ledgerName}`);
+        await this.disableDeletionProtection();
+        const request: DeleteLedgerRequest = {
+            Name: this.ledgerName
+        };
+        await this.qldbClient.deleteLedger(request).promise();
+    }
+
+    private async waitForDeletion(): Promise<void> {
+        console.log("Waiting for the ledger to be deleted...");
+        const request: DescribeLedgerRequest = {
+            Name: this.ledgerName
+        };
+        while (true) {
+            try {
+                await this.qldbClient.describeLedger(request).promise();
+                console.log("The ledger is still being deleted. Please wait...");
+                await TestUtils.sleep(10000);
+            } catch (e) {
+                if (isResourceNotFoundException(e)) {
+                    console.log("Success. Ledger is deleted.");
+                    break;
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private async disableDeletionProtection(): Promise<void> {
+        const request: UpdateLedgerRequest = {
+            Name: this.ledgerName,
+            DeletionProtection: false
+        }
+        await this.qldbClient.updateLedger(request).promise();
+    }
+
+    static getIonTypes(): dom.Value[] {
+        const values: dom.Value[] = [];
+
+        const ionClob: dom.Value = load('{{"This is a CLOB of text."}}');
+        values.push(ionClob);
+        const ionBlob: dom.Value = load('{{aGVsbG8=}}');
+        values.push(ionBlob);
+        const ionBool: dom.Value = load('true');
+        values.push(ionBool);
+        const ionDecimal: dom.Value = load('0.1');
+        values.push(ionDecimal);
+        const ionFloat: dom.Value = load('0.2e0');
+        values.push(ionFloat);
+        const ionInt: dom.Value = load('1');
+        values.push(ionInt);
+        const ionList: dom.Value = load('[1,2]');
+        values.push(ionList);
+        const ionNull: dom.Value = load('null');
+        values.push(ionNull);
+        const ionSexp: dom.Value = load('(cons 1 2)');
+        values.push(ionSexp);
+        const ionString: dom.Value = load('"string"');
+        values.push(ionString);
+        const ionStruct: dom.Value = load('{a:1}');
+        values.push(ionStruct);
+        const ionSymbol: dom.Value = load('abc');
+        values.push(ionSymbol);
+        const ionTimestamp: dom.Value = load('2016-12-20T05:23:43.000000-00:00');
+        values.push(ionTimestamp);
+
+        const ionNullClob: dom.Value = load('null.clob');
+        values.push(ionNullClob);
+        const ionNullBlob: dom.Value = load('null.blob');
+        values.push(ionNullBlob);
+        const ionNullBool: dom.Value = load('null.bool');
+        values.push(ionNullBool);
+        const ionNullDecimal: dom.Value = load('null.decimal');
+        values.push(ionNullDecimal);
+        const ionNullFloat: dom.Value = load('null.float');
+        values.push(ionNullFloat);
+        const ionNullInt: dom.Value = load('null.int');
+        values.push(ionNullInt);
+        const ionNullList: dom.Value = load('null.list');
+        values.push(ionNullList);
+        const ionNullSexp: dom.Value = load('null.sexp');
+        values.push(ionNullSexp);
+        const ionNullString: dom.Value = load('null.string');
+        values.push(ionNullString);
+        const ionNullStruct: dom.Value = load('null.struct');
+        values.push(ionNullStruct);
+        const ionNullSymbol: dom.Value = load('null.symbol');
+        values.push(ionNullSymbol);
+        const ionNullTimestamp: dom.Value = load('null.timestamp');
+        values.push(ionNullTimestamp);
+
+        const ionClobWithAnnotation: dom.Value = load('annotation::{{"This is a CLOB of text."}}');
+        values.push(ionClobWithAnnotation);
+        const ionBlobWithAnnotation: dom.Value = load('annotation::{{aGVsbG8=}}');
+        values.push(ionBlobWithAnnotation);
+        const ionBoolWithAnnotation: dom.Value = load('annotation::true');
+        values.push(ionBoolWithAnnotation);
+        const ionDecimalWithAnnotation: dom.Value = load('annotation::0.1');
+        values.push(ionDecimalWithAnnotation);
+        const ionFloatWithAnnotation: dom.Value = load('annotation::0.2e0');
+        values.push(ionFloatWithAnnotation);
+        const ionIntWithAnnotation: dom.Value = load('annotation::1');
+        values.push(ionIntWithAnnotation);
+        const ionListWithAnnotation: dom.Value = load('annotation::[1,2]');
+        values.push(ionListWithAnnotation);
+        const ionNullWithAnnotation: dom.Value = load('annotation::null');
+        values.push(ionNullWithAnnotation);
+        const ionSexpWithAnnotation: dom.Value = load('annotation::(cons 1 2)');
+        values.push(ionSexpWithAnnotation);
+        const ionStringWithAnnotation: dom.Value = load('annotation::"string"');
+        values.push(ionStringWithAnnotation);
+        const ionStructWithAnnotation: dom.Value = load('annotation::{a:1}');
+        values.push(ionStructWithAnnotation);
+        const ionSymbolWithAnnotation: dom.Value = load('annotation::abc');
+        values.push(ionSymbolWithAnnotation);
+        const ionTimestampWithAnnotation: dom.Value = load('annotation::2016-12-20T05:23:43.000000-00:00');
+        values.push(ionTimestampWithAnnotation);
+ 
+        return values;
+    }
+}

--- a/src/test/PooledQldbDriver.test.ts
+++ b/src/test/PooledQldbDriver.test.ts
@@ -15,19 +15,16 @@
 import "mocha";
 
 import { QLDBSession } from "aws-sdk";
-import { ClientConfiguration, SendCommandResult } from "aws-sdk/clients/qldbsession";
+import { ClientConfiguration } from "aws-sdk/clients/qldbsession";
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 import { Agent } from "https";
 import Semaphore from "semaphore-async-await";
 import * as sinon from "sinon";
 
-import { DriverClosedError, SessionPoolEmptyError } from "../errors/Errors";
-import * as LogUtil from "../LogUtil";
 import { PooledQldbDriver } from "../PooledQldbDriver";
 import { QldbDriver } from "../QldbDriver";
 import { QldbSession } from "../QldbSession";
-import { QldbSessionImpl } from "../QldbSessionImpl";
 import { Result } from "../Result";
 import { TransactionExecutor } from "../TransactionExecutor";
 
@@ -39,15 +36,8 @@ const testDefaultRetryLimit: number = 4;
 const testLedgerName: string = "LedgerName";
 const testMaxRetries: number = 0;
 const testMaxSockets: number = 10;
-const testMessage: string = "testMessage";
-const testSendCommandResult: SendCommandResult = {
-    StartSession: {
-        SessionToken: "sessionToken"
-    }
-};
 
 let pooledQldbDriver: PooledQldbDriver;
-let sendCommandStub;
 let testQldbLowLevelClient: QLDBSession;
 
 const mockAgent: Agent = <Agent><any> sandbox.mock(Agent);
@@ -64,6 +54,7 @@ const mockQldbSession: QldbSession = <QldbSession><any> sandbox.mock(QLDBSession
 mockQldbSession.executeLambda = async () => {
     return mockResult;
 }
+
 mockQldbSession.close = () => {
     return;
 }
@@ -71,13 +62,6 @@ mockQldbSession.close = () => {
 describe("PooledQldbDriver", () => {
     beforeEach(() => {
         testQldbLowLevelClient = new QLDBSession(testLowLevelClientOptions);
-        sendCommandStub = sandbox.stub(testQldbLowLevelClient, "sendCommand");
-        sendCommandStub.returns({
-            promise: () => {
-                return testSendCommandResult;
-            }
-        });
-
         pooledQldbDriver = new PooledQldbDriver(testLedgerName, testLowLevelClientOptions);
     });
 
@@ -128,148 +112,48 @@ describe("PooledQldbDriver", () => {
             };
             chai.assert.throws(constructorFunction, RangeError);
         });
+
     });
 
-    describe("#close()", () => {
-        it("should close pooledQldbDriver and any session present in the pool when called", () => {
-            const mockSession1: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
-            const mockSession2: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
-            mockSession1.close = () => {};
-            mockSession2.close = () => {};
-
-            const close1Spy = sandbox.spy(mockSession1, "close");
-            const close2Spy = sandbox.spy(mockSession2, "close");
-
-            pooledQldbDriver["_sessionPool"] = [mockSession1, mockSession2];
+    describe("#close", () => {
+        it("should call close of super class", async () => {
+            const qldbDriverCloseSpy = sandbox.spy(QldbDriver.prototype, "close");
             pooledQldbDriver.close();
-
-            sinon.assert.calledOnce(close1Spy);
-            sinon.assert.calledOnce(close2Spy);
-            chai.assert.equal(pooledQldbDriver["_isClosed"], true);
+            sinon.assert.calledOnce(qldbDriverCloseSpy);
         });
     });
 
-    describe("#executeLambda()", () => {
-        it("should start a session and return the delegated call to the session", async () => {
-            const getSessionStub = sandbox.stub(pooledQldbDriver, "getSession");
-            getSessionStub.returns(Promise.resolve(mockQldbSession));
-            const executeLambdaSpy = sandbox.spy(mockQldbSession, "executeLambda");
-            const closeSessionSpy = sandbox.spy(mockQldbSession, "close");
-            const lambda = (transactionExecutor: TransactionExecutor) => {
-                return true;
-            };
-            const retryIndicator = (retry: number) => {
-                return;
-            };
-            const result = await pooledQldbDriver.executeLambda(lambda, retryIndicator);
-
-            chai.assert.equal(result, mockResult);
-            sinon.assert.calledOnce(executeLambdaSpy);
-            sinon.assert.calledWith(executeLambdaSpy, lambda, retryIndicator);
-            sinon.assert.calledOnce(closeSessionSpy);
-        });
-
-        it("should throw DriverClosedError wrapped in a rejected promise when closed", async () => {
-            const lambda = (transactionExecutor: TransactionExecutor) => {
-                return true;
-            };
-            const retryIndicator = (retry: number) => {
-                return;
-            };
-
-            pooledQldbDriver["_isClosed"] = true;
-            const error = await chai.expect(pooledQldbDriver.executeLambda(lambda, retryIndicator)).to.be.rejected;
-            chai.assert.instanceOf(error, DriverClosedError);
-        });
-    });
-
-    describe("#getSession()", () => {
-        it("should return a DriverClosedError wrapped in a rejected promise when closed", async () => {
-            pooledQldbDriver["_isClosed"] = true;
-            const error = await chai.expect(pooledQldbDriver.getSession()).to.be.rejected;
-            chai.assert.instanceOf(error, DriverClosedError);
-        });
-
-        it("should return a new session when called", async () => {
-            pooledQldbDriver["_qldbClient"] = testQldbLowLevelClient;
-
-            const semaphoreStub = sandbox.stub(pooledQldbDriver["_semaphore"], "waitFor");
-            semaphoreStub.returns(Promise.resolve(true));
-
-            const qldbDriverGetSessionSpy = sandbox.spy(QldbDriver.prototype, "getSession");
-            const logDebugSpy = sandbox.spy(LogUtil, "debug");
-
-            const pooledQldbSession: QldbSession = await pooledQldbDriver.getSession();
-
-            sinon.assert.calledOnce(qldbDriverGetSessionSpy);
-            sinon.assert.calledOnce(semaphoreStub);
-            sinon.assert.calledThrice(logDebugSpy);
-
-            chai.assert.instanceOf(pooledQldbSession["_session"], QldbSessionImpl);
-            chai.assert.equal(pooledQldbSession["_returnSessionToPool"], pooledQldbDriver["_returnSessionToPool"]);
-            chai.assert.equal(pooledQldbDriver["_availablePermits"], testMaxSockets - 1);
-
-        });
-
-        it("should return the existing session already present in the session pool when called", async () => {
-            const mockSession: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
-            mockSession["_abortOrClose"] = async () => {
-                return true;
-            };
-
-            pooledQldbDriver["_sessionPool"] = [mockSession];
-            pooledQldbDriver["_qldbClient"] = testQldbLowLevelClient;
-
-            const logDebugSpy = sandbox.spy(LogUtil, "debug");
-            const abortOrCloseSpy = sandbox.spy(mockSession as any, "_abortOrClose");
-
-            const semaphoreStub = sandbox.stub(pooledQldbDriver["_semaphore"], "waitFor");
-            semaphoreStub.returns(Promise.resolve(true));
-
-            const pooledQldbSession: QldbSession = await pooledQldbDriver.getSession();
-
-            sinon.assert.calledTwice(logDebugSpy);
-            sinon.assert.calledOnce(abortOrCloseSpy);
-
-            chai.assert.equal(pooledQldbSession["_session"], mockSession);
-            chai.assert.equal(pooledQldbSession["_returnSessionToPool"], pooledQldbDriver["_returnSessionToPool"]);
-            chai.assert.deepEqual(pooledQldbDriver["_sessionPool"], []);
-            chai.assert.equal(pooledQldbDriver["_availablePermits"], testMaxSockets - 1);
-        });
-
-        it("should return a rejected promise when error is thrown", async () => {
+    describe("#getSession", () => {
+        it("should call getSession of super class", async () => {
             const qldbDriverGetSessionStub = sandbox.stub(QldbDriver.prototype, "getSession");
-            qldbDriverGetSessionStub.returns(Promise.reject(new Error(testMessage)));
-
-            const semaphoreReleaseSpy = sandbox.spy(pooledQldbDriver["_semaphore"], "release");
-
-            await chai.expect(pooledQldbDriver.getSession()).to.be.rejected;
-            chai.assert.equal(pooledQldbDriver["_availablePermits"], testMaxSockets);
-            sinon.assert.calledOnce(semaphoreReleaseSpy);
-        });
-
-        it("should return a SessionPoolEmptyError wrapped in a rejected promise when session pool empty", async () => {
-            const semaphoreStub = sandbox.stub(pooledQldbDriver["_semaphore"], "waitFor");
-            semaphoreStub.returns(Promise.resolve(false));
-
-            const error = await chai.expect(pooledQldbDriver.getSession()).to.be.rejected;
-            chai.assert.instanceOf(error, SessionPoolEmptyError);
+            qldbDriverGetSessionStub.returns(Promise.resolve(mockQldbSession));
+            await pooledQldbDriver.getSession();
+            sinon.assert.calledOnce(qldbDriverGetSessionStub);
         });
     });
 
-    describe("#releaseSession()", () => {
-        it("should return a session back to the session pool when called", () => {
-            const logDebugSpy = sandbox.spy(LogUtil, "debug");
-            const semaphoreReleaseSpy = sandbox.spy(pooledQldbDriver["_semaphore"], "release")
-            const mockSession: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
+    describe("#executeLambda", () => {
+        it("should call executeLambda of super class", async () => {
+            const qldbDriverGetSessionStub = sandbox.stub(QldbDriver.prototype, "executeLambda");
+            qldbDriverGetSessionStub.returns(Promise.resolve(true));
 
-            pooledQldbDriver["_returnSessionToPool"](mockSession);
+            const lambda = (transactionExecutor: TransactionExecutor) => {
+                return true;
+            };
+            const retryIndicator = (retry: number) => {
+                return;
+            };
+            await pooledQldbDriver.executeLambda(lambda, retryIndicator);
+            sinon.assert.calledOnce(qldbDriverGetSessionStub);
+        });
+    });
 
-            chai.assert.deepEqual(pooledQldbDriver["_sessionPool"], [mockSession])
-            chai.assert.deepEqual(pooledQldbDriver["_availablePermits"], testMaxSockets + 1)
-
-            sinon.assert.calledOnce(logDebugSpy);
-            sinon.assert.calledOnce(semaphoreReleaseSpy);
+    describe("#getTableNames", () => {
+        it("should call getTableNames of super class", async () => {
+            const qldbDriverGetTableNamesStub = sandbox.stub(QldbDriver.prototype, "getTableNames");
+            qldbDriverGetTableNamesStub.returns(Promise.resolve(["some-table-name"]));
+            await pooledQldbDriver.getTableNames();
+            sinon.assert.calledOnce(qldbDriverGetTableNamesStub);
         });
     });
 });

--- a/src/test/QldbDriver.test.ts
+++ b/src/test/QldbDriver.test.ts
@@ -18,21 +18,28 @@ import { QLDBSession } from "aws-sdk";
 import { ClientConfiguration, SendCommandResult } from "aws-sdk/clients/qldbsession";
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
+import { Agent } from "https";
+import Semaphore from "semaphore-async-await";
 import * as sinon from "sinon";
 
-import { DriverClosedError } from "../errors/Errors";
+import { DriverClosedError, SessionPoolEmptyError } from "../errors/Errors";
+import * as LogUtil from "../LogUtil";
 import { QldbDriver } from "../QldbDriver";
 import { QldbSession } from "../QldbSession";
+import { QldbSessionImpl } from "../QldbSessionImpl";
+import { Result } from "../Result";
+import { TransactionExecutor } from "../TransactionExecutor";
 
 chai.use(chaiAsPromised);
 const sandbox = sinon.createSandbox();
 
+const testDefaultTimeout: number = 30000;
 const testDefaultRetryLimit: number = 4;
 const testLedgerName: string = "LedgerName";
-const testLowLevelClientOptions: ClientConfiguration = {
-    region: "fakeRegion"
-};
 const testMaxRetries: number = 0;
+const testMaxSockets: number = 10;
+const testMessage: string = "testMessage";
+const testTableNames: string[] = ["Vehicle", "Person"];
 const testSendCommandResult: SendCommandResult = {
     StartSession: {
         SessionToken: "sessionToken"
@@ -42,6 +49,24 @@ const testSendCommandResult: SendCommandResult = {
 let qldbDriver: QldbDriver;
 let sendCommandStub;
 let testQldbLowLevelClient: QLDBSession;
+
+const mockAgent: Agent = <Agent><any> sandbox.mock(Agent);
+mockAgent.maxSockets = testMaxSockets;
+const testLowLevelClientOptions: ClientConfiguration = {
+    region: "fakeRegion",
+    httpOptions: {
+        agent: mockAgent
+    }
+};
+
+const mockResult: Result = <Result><any> sandbox.mock(Result);
+const mockQldbSession: QldbSession = <QldbSession><any> sandbox.mock(QLDBSession);
+mockQldbSession.executeLambda = async () => {
+    return mockResult;
+}
+mockQldbSession.close = () => {
+    return;
+}
 
 describe("QldbDriver", () => {
     beforeEach(() => {
@@ -57,6 +82,7 @@ describe("QldbDriver", () => {
     });
 
     afterEach(() => {
+        mockAgent.maxSockets = testMaxSockets;
         sandbox.restore();
     });
 
@@ -67,36 +93,196 @@ describe("QldbDriver", () => {
             chai.assert.equal(qldbDriver["_isClosed"], false);
             chai.assert.instanceOf(qldbDriver["_qldbClient"], QLDBSession);
             chai.assert.equal(qldbDriver["_qldbClient"].config.maxRetries, testMaxRetries);
+            chai.assert.equal(qldbDriver["_timeoutMillis"], testDefaultTimeout);
+            chai.assert.equal(qldbDriver["_poolLimit"], mockAgent.maxSockets);
+            chai.assert.equal(qldbDriver["_availablePermits"], mockAgent.maxSockets);
+            chai.assert.deepEqual(qldbDriver["_sessionPool"], []);
+            chai.assert.instanceOf(qldbDriver["_semaphore"], Semaphore);
+            chai.assert.equal(qldbDriver["_semaphore"]["permits"], mockAgent.maxSockets);
         });
 
-        it("should throw RangeError when retryLimit less than zero passed in", () => {
+        it("should throw a RangeError when timeOutMillis less than zero passed in", () => {
+            const constructorFunction: () => void = () => {
+                new QldbDriver(testLedgerName, testLowLevelClientOptions, 4, 0, -1);
+            };
+            chai.assert.throws(constructorFunction, RangeError);
+        });
+
+        it("should throw a RangeError when retryLimit less than zero passed in", () => {
             const constructorFunction: () => void = () => {
                 new QldbDriver(testLedgerName, testLowLevelClientOptions, -1);
+            };
+            chai.assert.throws(constructorFunction, RangeError);
+        });
+
+        it("should throw a RangeError when poolLimit greater than maxSockets", () => {
+            const constructorFunction: () => void  = () => {
+                new QldbDriver(testLedgerName, testLowLevelClientOptions, 4, testMaxSockets + 1);
+            };
+            chai.assert.throws(constructorFunction, RangeError);
+        });
+
+        it("should throw a RangeError when poolLimit less than zero", () => {
+            const constructorFunction: () => void = () => {
+                new QldbDriver(testLedgerName, testLowLevelClientOptions, 4, -1);
             };
             chai.assert.throws(constructorFunction, RangeError);
         });
     });
 
     describe("#close()", () => {
-        it("should close qldbDriver when called", () => {
+        it("should close qldbDriver and any session present in the pool when called", () => {
+            const mockSession1: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
+            const mockSession2: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
+            mockSession1.close = () => {};
+            mockSession2.close = () => {};
+
+            const close1Spy = sandbox.spy(mockSession1, "close");
+            const close2Spy = sandbox.spy(mockSession2, "close");
+
+            qldbDriver["_sessionPool"] = [mockSession1, mockSession2];
             qldbDriver.close();
+
+            sinon.assert.calledOnce(close1Spy);
+            sinon.assert.calledOnce(close2Spy);
             chai.assert.equal(qldbDriver["_isClosed"], true);
         });
     });
 
+    describe("#executeLambda()", () => {
+        it("should start a session and return the delegated call to the session", async () => {
+            const getSessionStub = sandbox.stub(qldbDriver, "getSession");
+            getSessionStub.returns(Promise.resolve(mockQldbSession));
+            const executeLambdaSpy = sandbox.spy(mockQldbSession, "executeLambda");
+            const closeSessionSpy = sandbox.spy(mockQldbSession, "close");
+            const lambda = (transactionExecutor: TransactionExecutor) => {
+                return true;
+            };
+            const retryIndicator = (retry: number) => {
+                return;
+            };
+            const result = await qldbDriver.executeLambda(lambda, retryIndicator);
+
+            chai.assert.equal(result, mockResult);
+            sinon.assert.calledOnce(executeLambdaSpy);
+            sinon.assert.calledWith(executeLambdaSpy, lambda, retryIndicator);
+            sinon.assert.calledOnce(closeSessionSpy);
+        });
+
+        it("should throw DriverClosedError wrapped in a rejected promise when closed", async () => {
+            const lambda = (transactionExecutor: TransactionExecutor) => {
+                return true;
+            };
+            const retryIndicator = (retry: number) => {
+                return;
+            };
+
+            qldbDriver["_isClosed"] = true;
+            const error = await chai.expect(qldbDriver.executeLambda(lambda, retryIndicator)).to.be.rejected;
+            chai.assert.instanceOf(error, DriverClosedError);
+        });
+    });
+
     describe("#getSession()", () => {
-        it("should return a QldbSession object when called", async () => {
+        it("should return a DriverClosedError wrapped in a rejected promise when closed", async () => {
+            qldbDriver["_isClosed"] = true;
+            const error = await chai.expect(qldbDriver.getSession()).to.be.rejected;
+            chai.assert.instanceOf(error, DriverClosedError);
+        });
+
+        it("should return a new session when called", async () => {
             qldbDriver["_qldbClient"] = testQldbLowLevelClient;
 
-            const qldbSession: QldbSession = await qldbDriver.getSession();
-            chai.assert.equal(qldbSession["_retryLimit"], testDefaultRetryLimit);
-            chai.assert.equal(qldbSession["_communicator"]["_ledgerName"], testLedgerName);
-            chai.assert.equal(qldbSession["_communicator"]["_qldbClient"], testQldbLowLevelClient);
+            const semaphoreStub = sandbox.stub(qldbDriver["_semaphore"], "waitFor");
+            semaphoreStub.returns(Promise.resolve(true));
+
+            const logDebugSpy = sandbox.spy(LogUtil, "debug");
+
+            const pooledQldbSession: QldbSession = await qldbDriver.getSession();
+
+            sinon.assert.calledOnce(semaphoreStub);
+            sinon.assert.calledThrice(logDebugSpy);
+
+            chai.assert.instanceOf(pooledQldbSession["_session"], QldbSessionImpl);
+            chai.assert.equal(pooledQldbSession["_returnSessionToPool"], qldbDriver["_returnSessionToPool"]);
+            chai.assert.equal(qldbDriver["_availablePermits"], testMaxSockets - 1);
+
+        });
+
+        it("should return the existing session already present in the session pool when called", async () => {
+            const mockSession: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
+            mockSession["_abortOrClose"] = async () => {
+                return true;
+            };
+
+            qldbDriver["_sessionPool"] = [mockSession];
+            qldbDriver["_qldbClient"] = testQldbLowLevelClient;
+
+            const logDebugSpy = sandbox.spy(LogUtil, "debug");
+            const abortOrCloseSpy = sandbox.spy(mockSession as any, "_abortOrClose");
+
+            const semaphoreStub = sandbox.stub(qldbDriver["_semaphore"], "waitFor");
+            semaphoreStub.returns(Promise.resolve(true));
+
+            const pooledQldbSession: QldbSession = await qldbDriver.getSession();
+
+            sinon.assert.calledTwice(logDebugSpy);
+            sinon.assert.calledOnce(abortOrCloseSpy);
+
+            chai.assert.equal(pooledQldbSession["_session"], mockSession);
+            chai.assert.equal(pooledQldbSession["_returnSessionToPool"], qldbDriver["_returnSessionToPool"]);
+            chai.assert.deepEqual(qldbDriver["_sessionPool"], []);
+            chai.assert.equal(qldbDriver["_availablePermits"], testMaxSockets - 1);
+        });
+
+        it("should return a rejected promise when error is thrown", async () => {
+            let error:Error = new Error("popping from pool failed");
+            const sessionPoolStub = sandbox.stub(qldbDriver["_sessionPool"], "pop");
+            sessionPoolStub.throws(error);
+
+            const semaphoreReleaseSpy = sandbox.spy(qldbDriver["_semaphore"], "release");
+
+            await chai.expect(qldbDriver.getSession()).to.be.rejected;
+            chai.assert.equal(qldbDriver["_availablePermits"], testMaxSockets);
+            sinon.assert.calledOnce(semaphoreReleaseSpy);
+        });
+
+        it("should return a SessionPoolEmptyError wrapped in a rejected promise when session pool empty", async () => {
+            const semaphoreStub = sandbox.stub(qldbDriver["_semaphore"], "waitFor");
+            semaphoreStub.returns(Promise.resolve(false));
+
+            const error = await chai.expect(qldbDriver.getSession()).to.be.rejected;
+            chai.assert.instanceOf(error, SessionPoolEmptyError);
+        });
+    });
+
+    describe("#releaseSession()", () => {
+        it("should return a session back to the session pool when called", () => {
+            const logDebugSpy = sandbox.spy(LogUtil, "debug");
+            const semaphoreReleaseSpy = sandbox.spy(qldbDriver["_semaphore"], "release")
+            const mockSession: QldbSessionImpl = <QldbSessionImpl><any> sandbox.mock(QldbSessionImpl);
+
+            qldbDriver["_returnSessionToPool"](mockSession);
+
+            chai.assert.deepEqual(qldbDriver["_sessionPool"], [mockSession])
+            chai.assert.deepEqual(qldbDriver["_availablePermits"], testMaxSockets + 1)
+
+            sinon.assert.calledOnce(logDebugSpy);
+            sinon.assert.calledOnce(semaphoreReleaseSpy);
+        });
+    });
+    describe("#getTableNames()", () => {
+        it("should return a list of table names when called", async () => {
+            const executeStub = sandbox.stub(qldbDriver, "executeLambda");
+            executeStub.returns(Promise.resolve(testTableNames));
+            const listOfTableNames: string[] = await qldbDriver.getTableNames();
+            chai.assert.equal(listOfTableNames.length, testTableNames.length);
+            chai.assert.equal(listOfTableNames, testTableNames);
         });
 
         it("should return a DriverClosedError wrapped in a rejected promise when closed", async () => {
             qldbDriver["_isClosed"] = true;
-            const error = await chai.expect(qldbDriver.getSession()).to.be.rejected;
+            const error = await chai.expect(qldbDriver.getTableNames()).to.be.rejected;
             chai.assert.instanceOf(error, DriverClosedError);
         });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         "index.ts"
     ],
     "exclude": [
-        "**/*.test.ts"
+        "src/integrationtest/*",
+        "src/test/*"
     ]
 }


### PR DESCRIPTION
This PR introduces the changes for v1.0.0-rc.2.  The list of changes can also be found in [CHANGELOG](https://github.com/awslabs/amazon-qldb-driver-nodejs/blob/driver-v1.0.0-rc.2/CHANGELOG.md)
 
*Description of changes:*

Note: v1.0.0-rc.2 is backward compatible with v1.0.0-rc.1. However, we do recommend you to incorporate the following suggested changes.

**Session pooling functionality moved to `QldbDriver`** 
Up until and including v1.0.0-rc.1, the amazon-qldb-driver-nodejs vended two types of driver implementations: The standard `QldbDriver` and a `PooledQldbDriver`. As the name suggests, the `PooledQldbDriver` maintained a pool of sessions which allowed you to reuse the underlying connections. 
Over a period of time, we realized that customers would just want to use the pooling mechanism for its benefits instead of the standard driver. 

And hence, we have decided to move the pooling functionality into `QldbDriver` and mark the `PooledQldbDriver` as @deprecated. 

This implies two changes:

1. If you have been using `PooledQldbDriver` simply replace that with `QldbDriver`.  The signature of the constructor and all the methods are same for both the drivers. So apart from instantiation, no more changes are required. You can continue to use the `PooledQldbDriver` but we will log a warning for using a @deprecated version.


   **Before**

   ```
   let qldbDriver: PooledQldbDriver = new PooledQdbDriver(..)
   ```

   **After**

   ```
   let qldbDriver: QldbDriver = new QldbDriver(..)
   ```

2. If you have been using the standard QldbDriver, you can now pass the additional parameters to the constructor. Please check the documentation of the class `QldbDriver`

**Helper method `getTableNames` now available on the driver instance**

The QldbSession exposed a helper method called `getTableNames` which listed all the tables present in your ledger.

With this release, this method is now also available on `QldbDriver` instance. We recommend you to change the code to use the `getTableNames` method on driver instance. We have marked `getTableNames` method as @deprecated.

**Before**

```
let session: QldbSession = await driver.getSession();
let tableNames: String[] = await session.getTableNames();
```

**After**

``` 
let tableNames: String[] = await driver.getTableNames();
```



**Use `executeLambda` method on the driver**

If you have been using `executeLambda` method on a session instance, we recommend you to instead use the `executeLambda` method on the driver instance. We have marked the `executeLambda` method on the session instance as @deprecated.

**Before**

```
let session: QldbSession = await driver.getSession();
session.executeLambda(..)
```

**After**

```
driver.executeLambda(..)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
