### PR TITLE
Fix typo in the argument name

### DIFF
--- a/src/QldbDriver.ts
+++ b/src/QldbDriver.ts
@@ -154,13 +154,13 @@ export class QldbDriver {
      * @param retryIndicator An Optional function which will be invoked when the `transactionFunction` is about to be retried due to a failure.
      */
     async executeLambda(
-        transactionFuntion: (transactionExecutor: TransactionExecutor) => any,
+        transactionFunction: (transactionExecutor: TransactionExecutor) => any,
         retryIndicator?: (retryAttempt: number) => void
     ): Promise<any> {
         let session: QldbSession = null;
         try  {
             session = await this.getSession();
-            return await session.executeLambda(transactionFuntion, retryIndicator);
+            return await session.executeLambda(transactionFunction, retryIndicator);
         } finally {
             if (session != null) {
                 session.close();


### PR DESCRIPTION
Resolves #37 

Fixed the typo in the argument name of `executeLambda` API. 

The typo and the correction does not impact the usage of the method and requires no code changes for the users of the API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
