### PR TITLE
Add jsbi to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "peerDependencies": {
     "aws-sdk": "^2.546.0",
-    "ion-js": "~4.0.0"
+    "ion-js": "~4.0.0",
+    "jsbi": "~3.1.1"
   },
   "scripts": {
     "build": "npm run lint && tsc",


### PR DESCRIPTION
With the [v1.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0-rc.1) release, the driver added jsbi as peer dependencies. Adding jsbi to `peerDependencies` in package.json will help users to find that change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
