### PR TITLE
Upload the release v2.0.0 of the Amazon QLDB driver for Node.js.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0 (2020-08-27)
+
+The release candidate 1 (v2.0.0-rc.1) has been selected as a final release of v2.0.0. No new changes are introduced between v2.0.0-rc.1 and v2.0.0.
+Please check the [release notes](http://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0)
+
 # 2.0.0-rc.1 (2020-08-13)
 
 ***Note: This version is a release candidate. We might introduce some additional changes before releasing v2.0.0.***

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon QLDB Node.js Driver
 
-[![NPM Version](https://img.shields.io/badge/npm-v2.0.0--rc.1-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs)  [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
+[![NPM Version](https://img.shields.io/badge/npm-v2.0.0-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs)  [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
 
 This is the Node.js driver for Amazon Quantum Ledger Database (QLDB), which allows Node.js developers to write software that makes use of AmazonQLDB.
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "amazon-qldb-driver-nodejs",
   "description": "The Node.js driver for working with Amazon Quantum Ledger Database",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {


### PR DESCRIPTION
This PR introduces `v2.0.0` (GA) of Amazon QLDB driver for Node.js. There are no code changes between `v2.0.0-rc.1` to `v2.0.0`

## Migrating from v2.0.0-rc.1 to v2.0.0

If you have been using [v2.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0-rc.1), you just need to change the version of `amazon-qldb-driver-nodejs` in your application’s `package.json` file. There are no code changes required. 


## Migrating from v1.x to v2.0.0

Please note the breaking changes mentioned in the release notes of [v2.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0-rc.1) and change your application code accordingly.

## Migrating from v0.x to v2.0.0

Follow the migration guide mentioned in release notes of [v1.0.0](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v1.0.0) along with the changes mentioned in the release notes of [v2.0.0-rc.1](https://github.com/awslabs/amazon-qldb-driver-nodejs/releases/tag/v2.0.0-rc.1)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
