### PR TITLE
Update mock to use Error instead of AWSError for Driver V2

### DIFF
--- a/src/test/Errors.test.ts
+++ b/src/test/Errors.test.ts
@@ -42,7 +42,7 @@ chai.use(chaiAsPromised);
 const sandbox = sinon.createSandbox();
 
 const testMessage: string = "foo";
-const mockError: AWSError = <AWSError><any> sandbox.mock(AWSError);
+const mockError: AWSError = <AWSError><any> sandbox.mock(Error);
 
 describe("Errors", () => {
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Error unit tests are failing because of a recent SDK [change](https://github.com/aws/aws-sdk-js/pull/3514) which updated AWSError from `class` to `type`. Sinon mocks can't mock `type` so we need to update to `Error`.

Ran unit & integration tests successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
