### PR TITLE
Add execution stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.1.0
+Add support for obtaining basic server-side statistics on individual statement executions.
+
+## :tada: Enhancements
+* Added `IOUsage` and `TimingInformation` interface to provide server-side execution statistics
+   * IOUsage provides `getReadIOs(): number`
+   * TimingInformation provides `getProcessingTimeMilliseconds(): number`
+   * Added `getConsumedIOs(): IOUsage` and `getTimingInformation(): TimingInformation` to the `Result` and `ResultStream`
+   * `getConsumedIOs(): IOUsage` and `getTimingInformation(): TimingInformation` methods are stateful, meaning the statistics returned by them reflect the state at the time of method execution
+
 # 2.0.0 (2020-08-27)
 
 The release candidate 1 (v2.0.0-rc.1) has been selected as a final release of v2.0.0. No new changes are introduced between v2.0.0-rc.1 and v2.0.0.

--- a/index.ts
+++ b/index.ts
@@ -12,5 +12,7 @@ export { Result } from "./src/Result";
 export { Transaction } from "./src/Transaction";
 export { TransactionExecutor } from "./src/TransactionExecutor";
 export { RetryConfig } from "./src/retry/RetryConfig";
+export { IOUsage } from "./src/stats/IOUsage";
+export { TimingInformation } from "./src/stats/TimingInformation";
 export { BackoffFunction } from "./src/retry/BackoffFunction";
 export { defaultRetryConfig } from "./src/retry/DefaultRetryConfig"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "amazon-qldb-driver-nodejs",
   "description": "The Node.js driver for working with Amazon Quantum Ledger Database",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
@@ -19,7 +19,7 @@
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",
-    "aws-sdk": "^2.546.0",
+    "aws-sdk": "^2.815.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^6.0.3",
@@ -37,7 +37,7 @@
     "typescript": "^3.5.3"
   },
   "peerDependencies": {
-    "aws-sdk": "^2.546.0",
+    "aws-sdk": "^2.815.0",
     "ion-js": "~4.0.0",
     "jsbi": "~3.1.1"
   },

--- a/src/QldbDriver.ts
+++ b/src/QldbDriver.ts
@@ -20,8 +20,8 @@ import Semaphore from "semaphore-async-await";
 import { version } from "../package.json";
 import { Communicator } from "./Communicator";
 import { defaultRetryConfig } from "./retry/DefaultRetryConfig";
-import { 
-    DriverClosedError, 
+import {
+    DriverClosedError,
     isInvalidSessionException,
     isTransactionExpiredException,
     SessionPoolEmptyError,
@@ -72,7 +72,7 @@ export class QldbDriver {
      *                                  The maxConcurrentTransactions parameter specifies the number of sessions that the driver can hold in the pool.
      *                                  The default is set to maximum number of sockets specified in the globalAgent.
      *                                  See {@link https://docs.aws.amazon.com/qldb/latest/developerguide/driver.best-practices.html#driver.best-practices.configuring} for more details.
-     * @param RetryConfig Config to specify max number of retries, base and custom backoff strategy for retries. Will be overridden if a different retry_config
+     * @param retryConfig Config to specify max number of retries, base and custom backoff strategy for retries. Will be overridden if a different retryConfig
      *                    is passed to {@linkcode executeLambda}.
      *
      * @throws RangeError if `maxConcurrentTransactions` is less than 0.
@@ -146,8 +146,8 @@ export class QldbDriver {
      * The function passed via retryIndicator parameter is invoked whenever there is a failure and the driver is about to retry the transaction.
      * The retryIndicator will be called with the current attempt number.
      *
-     * @param transactionFunction The function representing a transaction to be executed. Please see the method docs to understand the usage of this parameter.
-     * @param retryConfig Config to specify max number of retries, base and custom backoff strategy for retries. This config 
+     * @param transactionLambda The function representing a transaction to be executed. Please see the method docs to understand the usage of this parameter.
+     * @param retryConfig Config to specify max number of retries, base and custom backoff strategy for retries. This config
      *                    overrides the retry config set at driver level for a particular lambda execution.
      *                    Note that all the values of the driver level retry config will be overridden by the new config passed here.
      * @throws {@linkcode DriverClosedError} When a transaction is attempted on a closed driver instance. {@linkcode close}
@@ -171,7 +171,7 @@ export class QldbDriver {
                 return await session.executeLambda(transactionLambda, retryConfig, transactionExecutionContext);
             } catch(err) {
                 /* This is a guard condition to prevent the driver from entering an infinite loop
-                if all the sessions start resulting in InvalidSessionException 
+                if all the sessions start resulting in InvalidSessionException
                 */
                 if (transactionExecutionAttempt >= this._maxConcurrentTransactions + 3) {
                     throw err;

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -127,8 +127,7 @@ export class Transaction implements TransactionExecutable {
      */
     async execute(statement: string, ...parameters: any[]): Promise<Result> {
         const result: ExecuteStatementResult = await this._sendExecute(statement, parameters);
-        const inlineResult = Result.create(this._txnId, result.FirstPage, this._communicator);
-        return inlineResult;
+        return Result.create(this._txnId, result, this._communicator);
     }
 
     /**
@@ -146,7 +145,7 @@ export class Transaction implements TransactionExecutable {
      */
     async executeAndStreamResults(statement: string, ...parameters: any[]): Promise<Readable> {
         const result: ExecuteStatementResult = await this._sendExecute(statement, parameters);
-        return new ResultStream(this._txnId, result.FirstPage, this._communicator);
+        return new ResultStream(this._txnId, result, this._communicator);
     }
 
     /**

--- a/src/stats/IOUsage.ts
+++ b/src/stats/IOUsage.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * Provides metrics on IO usage of requests.
+ */
+export class IOUsage {
+    private _readIOs: number;
+
+    /**
+     * Creates an IOUsage.
+     * @param readIOs The number of Read IOs.
+     */
+    constructor(readIOs: number) {
+        this._readIOs = readIOs;
+    }
+
+    /**
+     * Provides the number of Read IOs for a request.
+     * @returns The number of Reads for a request.
+     */
+    getReadIOs(): number {
+        return this._readIOs;
+    }
+}

--- a/src/stats/TimingInformation.ts
+++ b/src/stats/TimingInformation.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * Provides metrics on server-side processing time for requests.
+ */
+export class TimingInformation {
+    private _processingTimeMilliseconds: number;
+
+    /**
+     * Creates a TimingInformation.
+     * @param processingTimeMilliseconds The server-side processing time in milliseconds.
+     */
+    constructor(processingTimeMilliseconds: number) {
+        this._processingTimeMilliseconds = processingTimeMilliseconds;
+    }
+
+    /**
+     * Provides the server-side time spent on a request.
+     * @returns The server-side processing time in millisecond.
+     */
+    getProcessingTimeMilliseconds(): number {
+        return this._processingTimeMilliseconds;
+    }
+}

--- a/src/test/QldbSession.test.ts
+++ b/src/test/QldbSession.test.ts
@@ -19,7 +19,6 @@ import {
     AbortTransactionResult,
     ClientConfiguration,
     ExecuteStatementResult,
-    Page,
     PageToken,
     StartTransactionResult,
     ValueHolder
@@ -44,7 +43,6 @@ chai.use(chaiAsPromised);
 const sandbox = sinon.createSandbox();
 
 const testRetryLimit: number = 4;
-const testLedgerName: string = "fakeLedgerName";
 const testSessionToken: string = "sessionToken";
 const testTransactionId: string = "txnId";
 const testStartTransactionResult: StartTransactionResult = {
@@ -53,9 +51,6 @@ const testStartTransactionResult: StartTransactionResult = {
 const testMessage: string = "foo";
 const testStatement: string = "SELECT * FROM foo";
 const testAbortTransactionResult: AbortTransactionResult = {};
-
-const TEST_SLEEP_CAP_MS: number = 5000;
-const TEST_SLEEP_BASE_MS: number = 10;
 
 const testValueHolder: ValueHolder[] = [{IonBinary: "{ hello:\"world\" }"}];
 const testPageToken: PageToken = "foo";
@@ -69,16 +64,15 @@ const mockLowLevelClientOptions: ClientConfiguration = {
     region: "fakeRegion"
 };
 const testQldbLowLevelClient: QLDBSession = new QLDBSession(mockLowLevelClientOptions);
-const testPage: Page = {};
 
 const mockCommunicator: Communicator = <Communicator><any> sandbox.mock(Communicator);
 const mockResult: Result = <Result><any> sandbox.mock(Result);
 const mockTransaction: Transaction = <Transaction><any> sandbox.mock(Transaction);
 mockTransaction.getTransactionId = () => {
     return "mockTransactionId";
-}
+};
 
-const resultStreamObject: ResultStream = new ResultStream(testTransactionId, testPage, mockCommunicator);
+const resultStreamObject: ResultStream = new ResultStream(testTransactionId, testExecuteStatementResult, mockCommunicator);
 let qldbSession: QldbSession;
 let executionContext: TransactionExecutionContext;
 
@@ -343,7 +337,7 @@ describe("QldbSession", () => {
     });
 
     describe("#RetryDelayTime()", () => {
-        /* Test that the 
+        /* Test that the
             1. Default retry policy increases delay exponentially (when math.random is overriden to return 1)
             2. _sleep method gets called with the calculated delay time
         */
@@ -352,7 +346,7 @@ describe("QldbSession", () => {
             const mathRandStub = sandbox.stub(Math, "random");
             mathRandStub.returns(1);
             let executionContext: TransactionExecutionContext = new TransactionExecutionContext();
-            let defaultBackOffFunction: BackoffFunction = defaultRetryConfig.getBackoffFunction(); 
+            let defaultBackOffFunction: BackoffFunction = defaultRetryConfig.getBackoffFunction();
 
             //Increment the attempt number to 1 and determine what the delay time would be when using default retry policy
             executionContext.incrementExecutionAttempt();

--- a/src/test/ResultStream.test.ts
+++ b/src/test/ResultStream.test.ts
@@ -14,7 +14,13 @@
 // Test environment imports
 import "mocha";
 
-import { Page, ValueHolder } from "aws-sdk/clients/qldbsession";
+import {
+    ExecuteStatementResult,
+    IOUsage as sdkIOUsage,
+    Page,
+    TimingInformation as sdkTimingInformation,
+    ValueHolder
+} from "aws-sdk/clients/qldbsession";
 import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 import { dom } from "ion-js";
@@ -23,6 +29,8 @@ import * as sinon from "sinon";
 import { Communicator } from "../Communicator";
 import { Result } from "../Result";
 import { ResultStream } from "../ResultStream";
+import { IOUsage } from "../stats/IOUsage";
+import { TimingInformation } from "../stats/TimingInformation";
 
 chai.use(chaiAsPromised);
 const sandbox = sinon.createSandbox();
@@ -40,6 +48,17 @@ const testPageWithToken: Page = {
     Values: testValues,
     NextPageToken: "nextPageToken"
 };
+const testExecuteStatementResult: ExecuteStatementResult = {
+    FirstPage: testPageWithToken,
+    TimingInformation: {
+        ProcessingTimeMilliseconds: 20
+    },
+    ConsumedIOs: {
+        ReadIOs: 5
+    }
+};
+const testIOUsage: IOUsage = new IOUsage(5);
+const testTimingInfo: TimingInformation = new TimingInformation(20);
 
 const mockCommunicator: Communicator = <Communicator><any> sandbox.mock(Communicator);
 mockCommunicator.fetchPage = async () => {
@@ -53,7 +72,11 @@ let resultStream: ResultStream;
 describe("ResultStream", () => {
 
     beforeEach(() => {
-        resultStream = new ResultStream(testTransactionId, testPageWithToken, mockCommunicator);
+        resultStream = new ResultStream(
+            testTransactionId,
+            testExecuteStatementResult,
+            mockCommunicator
+        );
     });
 
     afterEach(() => {
@@ -67,6 +90,8 @@ describe("ResultStream", () => {
             chai.assert.equal(testTransactionId, resultStream["_txnId"]);
             chai.assert.isTrue(resultStream["_shouldPushCachedPage"]);
             chai.assert.equal(0, resultStream["_retrieveIndex"]);
+            chai.assert.equal(testIOUsage.getReadIOs(), resultStream["_readIOs"]);
+            chai.assert.equal(testTimingInfo.getProcessingTimeMilliseconds(), resultStream["_processingTime"]);
         });
     });
 
@@ -74,7 +99,7 @@ describe("ResultStream", () => {
         it("should call _pushPageValues() when called", () => {
             resultStream["_pushPageValues"] = async (): Promise<void> => {
                 return;
-            }
+            };
             const _pushPageValuesSpy = sandbox.spy(resultStream as any, "_pushPageValues");
             resultStream._read();
             sinon.assert.calledOnce(_pushPageValuesSpy);
@@ -203,7 +228,7 @@ describe("ResultStream", () => {
             const destroyStub = sandbox.stub(resultStream, "destroy");
             const fetchPageStub: sinon.SinonStub = sandbox.stub(mockCommunicator, "fetchPage");
             fetchPageStub.throws(new Error(testMessage));
-            
+
             await resultStream["_pushPageValues"]();
 
             sinon.assert.calledOnce(destroyStub);
@@ -270,6 +295,193 @@ describe("ResultStream", () => {
             sinon.assert.calledWith(pushStub.getCall(2), 3);
             sinon.assert.calledOnce(_readStub);
             chai.assert.isFalse(resultStream["_shouldPushCachedPage"]);
+        });
+    });
+
+    describe("#getConsumedIOs", () => {
+        it("should return an IOUsage object with correct value without IO on next page in result", async () => {
+            mockCommunicator.fetchPage = async () => {
+                return {
+                    Page: testPage,
+                    ConsumedIOs: null
+                };
+            };
+            await resultStream["_pushPageValues"]();
+
+            const ioUsage: IOUsage = resultStream.getConsumedIOs();
+            chai.expect(ioUsage).to.be.an.instanceOf(IOUsage);
+            chai.expect(ioUsage.getReadIOs()).to.be.eq(testIOUsage.getReadIOs());
+        });
+
+        it("should return null if there are no IOs", async () => {
+            const testExecuteStatementResult: ExecuteStatementResult = {
+                FirstPage: testPageWithToken,
+                ConsumedIOs: null
+            };
+            resultStream = new ResultStream(
+                testTransactionId,
+                testExecuteStatementResult,
+                mockCommunicator
+            );
+
+            resultStream["_shouldPushCachedPage"] = false;
+            const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
+
+            await resultStream["_pushPageValues"]();
+
+            sinon.assert.called(fetchPageSpy);
+            chai.expect(resultStream.getConsumedIOs()).to.be.null;
+        });
+
+        it("should return accumulated number of IOs of the first page and next pages", async () => {
+            const nextPageConsumedIOs: sdkIOUsage = {
+                ReadIOs: 2
+            };
+            mockCommunicator.fetchPage = async () => {
+                return {
+                    Page: testPage,
+                    ConsumedIOs: nextPageConsumedIOs
+                };
+            };
+            const expectedAccumulatedIOs: number = testIOUsage.getReadIOs() + nextPageConsumedIOs.ReadIOs;
+
+            resultStream["_shouldPushCachedPage"] = false;
+            const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
+
+            await resultStream["_pushPageValues"]();
+
+            const ioUsage: IOUsage = resultStream.getConsumedIOs();
+
+            sinon.assert.called(fetchPageSpy);
+            chai.expect(ioUsage).to.be.an.instanceOf(IOUsage);
+            chai.expect(ioUsage.getReadIOs()).to.be.eq(expectedAccumulatedIOs);
+        });
+
+        it("should return correct number of IOs if first page's IOs is null but next pages have IOs", async () => {
+            const testExecuteStatementResult: ExecuteStatementResult = {
+                FirstPage: testPageWithToken,
+                ConsumedIOs: null
+            };
+            resultStream = new ResultStream(
+                testTransactionId,
+                testExecuteStatementResult,
+                mockCommunicator
+            );
+            const nextPageConsumedIOs: sdkIOUsage = {
+                ReadIOs: 2
+            };
+            mockCommunicator.fetchPage = async () => {
+                return {
+                    Page: testPage,
+                    ConsumedIOs: nextPageConsumedIOs
+                };
+            };
+
+            resultStream["_shouldPushCachedPage"] = false;
+            const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
+
+            await resultStream["_pushPageValues"]();
+
+            const ioUsage: IOUsage = resultStream.getConsumedIOs();
+
+            sinon.assert.called(fetchPageSpy);
+            chai.expect(ioUsage).to.be.an.instanceOf(IOUsage);
+            chai.expect(ioUsage.getReadIOs()).to.be.eq(nextPageConsumedIOs.ReadIOs);
+        });
+    });
+
+    describe("#getTimingInformation", () => {
+        it("should return a TimingInformation object when called without TimingInformation on next page", async () => {
+            mockCommunicator.fetchPage = async () => {
+                return {
+                    Page: testPage,
+                    TimingInformation: null
+                };
+            };
+            await resultStream["_pushPageValues"]();
+
+            const timingInformation: TimingInformation = resultStream.getTimingInformation();
+            chai.expect(timingInformation).to.be.an.instanceOf(TimingInformation);
+            chai.expect(timingInformation.getProcessingTimeMilliseconds())
+                .to.be.eq(timingInformation.getProcessingTimeMilliseconds());
+        });
+
+        it("should return null if there is no processing time", async () => {
+            const testExecuteStatementResult: ExecuteStatementResult = {
+                FirstPage: testPageWithToken,
+                TimingInformation: null
+            };
+            resultStream = new ResultStream(
+                testTransactionId,
+                testExecuteStatementResult,
+                mockCommunicator
+            );
+
+            resultStream["_shouldPushCachedPage"] = false;
+            const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
+
+            await resultStream["_pushPageValues"]();
+
+            sinon.assert.called(fetchPageSpy);
+            chai.expect(resultStream.getTimingInformation()).to.be.null;
+        });
+
+        it("should return accumulated processing time for the first page and next pages", async () => {
+            const nextPageProcessingTime: sdkTimingInformation = {
+                ProcessingTimeMilliseconds: 10
+            };
+            mockCommunicator.fetchPage = async () => {
+                return {
+                    Page: testPage,
+                    TimingInformation: nextPageProcessingTime
+                };
+            };
+            const expectedAccumulatedProcessingTime: number = testTimingInfo.getProcessingTimeMilliseconds() +
+                nextPageProcessingTime.ProcessingTimeMilliseconds;
+
+            resultStream["_shouldPushCachedPage"] = false;
+            const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
+
+            await resultStream["_pushPageValues"]();
+
+            const timingInformation: TimingInformation = resultStream.getTimingInformation();
+
+            sinon.assert.called(fetchPageSpy);
+            chai.expect(timingInformation).to.be.an.instanceOf(TimingInformation);
+            chai.expect(timingInformation.getProcessingTimeMilliseconds()).to.be.eq(expectedAccumulatedProcessingTime);
+        });
+
+        it("should return correct processing time if there is no time on first page but next pages has", async () => {
+            const testExecuteStatementResult: ExecuteStatementResult = {
+                FirstPage: testPageWithToken,
+                TimingInformation: null
+            };
+            resultStream = new ResultStream(
+                testTransactionId,
+                testExecuteStatementResult,
+                mockCommunicator
+            );
+            const nextPageProcessingTime: sdkTimingInformation = {
+                ProcessingTimeMilliseconds: 10
+            };
+            mockCommunicator.fetchPage = async () => {
+                return {
+                    Page: testPage,
+                    TimingInformation: nextPageProcessingTime
+                };
+            };
+
+            resultStream["_shouldPushCachedPage"] = false;
+            const fetchPageSpy = sandbox.spy(mockCommunicator, "fetchPage");
+
+            await resultStream["_pushPageValues"]();
+
+            const timingInformation: TimingInformation = resultStream.getTimingInformation();
+
+            sinon.assert.called(fetchPageSpy);
+            chai.expect(timingInformation).to.be.an.instanceOf(TimingInformation);
+            chai.expect(timingInformation.getProcessingTimeMilliseconds())
+                .to.be.eq(nextPageProcessingTime.ProcessingTimeMilliseconds);
         });
     });
  });

--- a/src/test/Transaction.test.ts
+++ b/src/test/Transaction.test.ts
@@ -17,7 +17,6 @@ import "mocha";
 import {
     CommitTransactionResult,
     ExecuteStatementResult,
-    Page,
     PageToken,
     ValueHolder
 } from "aws-sdk/clients/qldbsession";
@@ -50,7 +49,6 @@ const testCommitTransactionResult: CommitTransactionResult = {
     TransactionId: testTransactionId,
     CommitDigest: QldbHash.toQldbHash(testTransactionId).getQldbHash()
 };
-const pageToken: Page = {NextPageToken: testPageToken};
 const testExecuteStatementResult: ExecuteStatementResult = {
     FirstPage: {
         NextPageToken: testPageToken
@@ -271,7 +269,7 @@ describe("Transaction", () => {
         it("should return a Stream object when provided with a statement", async () => {
             const sampleResultStreamObject: ResultStream = new ResultStream(
                 testTransactionId,
-                pageToken,
+                testExecuteStatementResult,
                 mockCommunicator
             );
             const executeSpy = sandbox.spy(mockCommunicator, "executeStatement");
@@ -284,7 +282,7 @@ describe("Transaction", () => {
         it("should return a Stream object when provided with a statement and parameters", async () => {
             const sampleResultStreamObject: ResultStream = new ResultStream(
                 testTransactionId,
-                pageToken,
+                testExecuteStatementResult,
                 mockCommunicator
             );
             const sendExecuteSpy = sandbox.spy(transaction as any, "_sendExecute");


### PR DESCRIPTION
*Description of changes:*
This pull request is to add programmatic access to some server-side statistics on individual statement executions.

On both buffered result, `Result`, and stream result, `ResultStream`, 2 new functions are added to get some execution statistics:
- `getConsumedIOs(): IOUsage` to obtain number of IOs for statement executions.
   * IOUsage provides `getReadIOs(): number`
- `getTimingInformation(): TimingInformation` to obtain information on processing time of an execution.
   * TimingInformation provides `getProcessingTimeMilliseconds(): number`

In `ResultStream`, these methods are stateful, meaning the statistics returned by them reflect the state at the time of method execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
