### PR TITLE
Export ResultReadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.1
+* Export `ResultReadable`.
+* Change the return type of `executeAndStreamResults()` from `Readable` to `ResultReadable` which extends `Readable`.
+* `getConsumedIOs(): IOUsage` and `getTimingInformation(): TimingInformation` functions, are accessible through `ResultReadable`.
+
 # 2.1.0
 Add support for obtaining basic server-side statistics on individual statement executions.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon QLDB Node.js Driver
 
-[![NPM Version](https://img.shields.io/badge/npm-v2.1.0-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs)  [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
+[![NPM Version](https://img.shields.io/badge/npm-v2.1.1-green)](https://www.npmjs.com/package/amazon-qldb-driver-nodejs)  [![Documentation](https://img.shields.io/badge/docs-api-green.svg)](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html)
 
 This is the Node.js driver for Amazon Quantum Ledger Database (QLDB), which allows Node.js developers to write software that makes use of AmazonQLDB.
 

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./src/errors/Errors";
 export { QldbDriver } from "./src/QldbDriver";
 export { Result } from "./src/Result";
+export { ResultReadable } from "./src/ResultReadable";
 export { Transaction } from "./src/Transaction";
 export { TransactionExecutor } from "./src/TransactionExecutor";
 export { RetryConfig } from "./src/retry/RetryConfig";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "amazon-qldb-driver-nodejs",
   "description": "The Node.js driver for working with Amazon Quantum Ledger Database",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/QldbSession.ts
+++ b/src/QldbSession.ts
@@ -24,7 +24,7 @@ import {
 } from "./errors/Errors";
 import { warn } from "./LogUtil";
 import { Result } from "./Result";
-import { ResultStream } from "./ResultStream";
+import { ResultReadable } from "./ResultReadable";
 import { RetryConfig } from "./retry/RetryConfig";
 import { Transaction } from "./Transaction";
 import { TransactionExecutor } from "./TransactionExecutor";
@@ -63,8 +63,8 @@ export class QldbSession {
                 transaction = await this.startTransaction();
                 const transactionExecutor = new TransactionExecutor(transaction);
                 let returnedValue: any = await transactionLambda(transactionExecutor);
-                if (returnedValue instanceof ResultStream) {
-                    returnedValue = await Result.bufferResultStream(returnedValue);
+                if (returnedValue instanceof ResultReadable) {
+                    returnedValue = await Result.bufferResultReadable(returnedValue);
                 }
                 await transaction.commit();
                 return returnedValue;

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -22,7 +22,7 @@ import { dom } from "ion-js";
 
 import { Communicator } from "./Communicator";
 import { ClientException } from "./errors/Errors"
-import { ResultStream } from "./ResultStream";
+import { ResultReadable } from "./ResultReadable";
 import { IOUsage } from "./stats/IOUsage";
 import { TimingInformation } from "./stats/TimingInformation";
 
@@ -63,13 +63,13 @@ export class Result {
     }
 
     /**
-     * Static method that creates a Result object by reading and buffering the contents of a ResultStream.
-     * @param resultStream A ResultStream object to convert to a Result object.
+     * Static method that creates a Result object by reading and buffering the contents of a ResultReadable.
+     * @param resultReadable A ResultReadable object to convert to a Result object.
      * @returns Promise which fulfills with a Result.
      */
-    static async bufferResultStream(resultStream: ResultStream): Promise<Result> {
-        const resultList: dom.Value[] = await Result._readResultStream(resultStream);
-        return new Result(resultList, resultStream.getConsumedIOs(), resultStream.getTimingInformation());
+    static async bufferResultReadable(resultReadable: ResultReadable): Promise<Result> {
+        const resultList: dom.Value[] = await Result._readResultReadable(resultReadable);
+        return new Result(resultList, resultReadable.getConsumedIOs(), resultReadable.getTimingInformation());
     }
 
     /**
@@ -166,14 +166,14 @@ export class Result {
     }
 
     /**
-     * Helper method that reads a ResultStream and extracts the results, placing them in an array of Ion values.
-     * @param resultStream The ResultStream to read.
+     * Helper method that reads a ResultReadable and extracts the results, placing them in an array of Ion values.
+     * @param resultReadable The ResultReadable to read.
      * @returns Promise which fulfills with a list of Ion values, representing all the returned values of the result set.
      */
-    private static async _readResultStream(resultStream: ResultStream): Promise<dom.Value[]> {
+    private static async _readResultReadable(resultReadable: ResultReadable): Promise<dom.Value[]> {
         return new Promise(res => {
             let ionValues: dom.Value[] = [];
-            resultStream.on("data", function(value) {
+            resultReadable.on("data", function(value) {
                 ionValues.push(value);
             }).on("end", function() {
                 res(ionValues);

--- a/src/ResultReadable.ts
+++ b/src/ResultReadable.ts
@@ -29,7 +29,7 @@ import { TimingInformation } from "./stats/TimingInformation";
  * Extends Readable from the Node.JS Stream API interface.
  * The stream will always operate in object mode.
  */
-export class ResultStream extends Readable {
+export class ResultReadable extends Readable {
     private _communicator: Communicator;
     private _cachedPage: Page;
     private _txnId: string;
@@ -40,7 +40,7 @@ export class ResultStream extends Readable {
     private _processingTime: number;
 
     /**
-     * Create a ResultStream.
+     * Create a ResultReadable.
      * @param txnId The ID of the transaction the statement was executed in.
      * @param executeResult The returned result from the statement execution.
      * @param communicator The Communicator used for the statement execution.
@@ -69,7 +69,7 @@ export class ResultStream extends Readable {
     }
 
     /**
-     * Returns server-side processing time for the executed statement. The statistics are stateful
+     * Returns server-side processing time for the executed statement. The statistics are stateful.
      * @returns TimingInformation, containing processing time.
      */
     getTimingInformation(): TimingInformation {

--- a/src/TransactionExecutable.ts
+++ b/src/TransactionExecutable.ts
@@ -11,9 +11,8 @@
  * and limitations under the License.
  */
 
-import { Readable } from "stream";
-
 import { Result } from "./Result";
+import { ResultReadable } from "./ResultReadable";
 
 /**
  * Interface for execution against QLDB in the context of a transaction.
@@ -35,5 +34,5 @@ export interface TransactionExecutable {
      *                   filling in parameters of the statement.
      * @returns Promise which fulfills with a Readable.
      */
-    executeAndStreamResults(statement: string, ...parameters: any[]): Promise<Readable>;
+    executeAndStreamResults(statement: string, ...parameters: any[]): Promise<ResultReadable>;
 }

--- a/src/TransactionExecutor.ts
+++ b/src/TransactionExecutor.ts
@@ -11,10 +11,9 @@
  * and limitations under the License.
  */
 
-import { Readable } from "stream";
-
 import { LambdaAbortedError } from "./errors/Errors";
 import { Result } from "./Result";
+import { ResultReadable } from "./ResultReadable";
 import { Transaction } from "./Transaction";
 import { TransactionExecutable } from "./TransactionExecutable";
 
@@ -77,7 +76,7 @@ export class TransactionExecutor implements TransactionExecutable {
      * @throws {@linkcode TransactionClosedError} when the transaction is closed.
      * @throws [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) when the passed argument value cannot be converted into Ion
      */
-    async executeAndStreamResults(statement: string, ...parameters: any[]): Promise<Readable> {
+    async executeAndStreamResults(statement: string, ...parameters: any[]): Promise<ResultReadable> {
         return await this._transaction.executeAndStreamResults(statement, ...parameters);
     }
 

--- a/src/test/QldbSession.test.ts
+++ b/src/test/QldbSession.test.ts
@@ -32,7 +32,7 @@ import * as Errors from "../errors/Errors";
 import * as LogUtil from "../LogUtil";
 import { QldbSession } from "../QldbSession";
 import { Result } from "../Result";
-import { ResultStream } from "../ResultStream";
+import { ResultReadable } from "../ResultReadable";
 import { BackoffFunction } from "../retry/BackoffFunction";
 import { defaultRetryConfig } from "../retry/DefaultRetryConfig";
 import { Transaction } from "../Transaction";
@@ -72,7 +72,7 @@ mockTransaction.getTransactionId = () => {
     return "mockTransactionId";
 };
 
-const resultStreamObject: ResultStream = new ResultStream(testTransactionId, testExecuteStatementResult, mockCommunicator);
+const resultReadableObject: ResultReadable = new ResultReadable(testTransactionId, testExecuteStatementResult, mockCommunicator);
 let qldbSession: QldbSession;
 let executionContext: TransactionExecutionContext;
 
@@ -151,14 +151,14 @@ describe("QldbSession", () => {
         });
 
         it("should return a Result object when called with executeAndStreamResults as the lambda", async () => {
-            const resultStub = sandbox.stub(Result, "bufferResultStream");
+            const resultStub = sandbox.stub(Result, "bufferResultReadable");
             resultStub.returns(Promise.resolve(mockResult));
 
             qldbSession.startTransaction = async () => {
                 return mockTransaction;
             };
             mockTransaction.executeAndStreamResults = async () => {
-                return resultStreamObject;
+                return resultReadableObject;
             };
             mockTransaction.commit = async () => {};
 

--- a/src/test/Result.test.ts
+++ b/src/test/Result.test.ts
@@ -30,7 +30,7 @@ import * as sinon from "sinon";
 import { Communicator } from "../Communicator";
 import { ClientException } from "../errors/Errors";
 import { Result } from "../Result";
-import { ResultStream } from "../ResultStream";
+import { ResultReadable } from "../ResultReadable";
 import { IOUsage } from "../stats/IOUsage";
 import { TimingInformation } from "../stats/TimingInformation";
 
@@ -86,14 +86,14 @@ describe("Result", () => {
         });
     });
 
-    describe("#bufferResultStream()", () => {
+    describe("#bufferResultReadable()", () => {
         it("should return a Result object when called", async () => {
-            const sampleResultStreamObject: ResultStream = new ResultStream(
+            const sampleResultReadableObject: ResultReadable = new ResultReadable(
                 testTransactionId,
                 testExecuteResult,
                 mockCommunicator
             );
-            const result = await Result.bufferResultStream(sampleResultStreamObject);
+            const result = await Result.bufferResultReadable(sampleResultReadableObject);
             chai.expect(result).to.be.an.instanceOf(Result);
         });
     });
@@ -251,7 +251,7 @@ describe("Result", () => {
             }
         });
 
-        it("should return a list of Ion values when Result object created with bufferResultStream()", async () => {
+        it("should return a list of Ion values when Result object created with bufferResultReadable()", async () => {
             const value1: ValueHolder = {IonBinary: "a"};
             const value2: ValueHolder = {IonBinary: "b"};
             const value3: ValueHolder = {IonBinary: "c"};
@@ -273,9 +273,9 @@ describe("Result", () => {
             const testExecuteResult: ExecuteStatementResult = {
                 FirstPage: testPage,
             };
-            const mockResultStream: ResultStream = new ResultStream(testTransactionId, testExecuteResult, mockCommunicator);
+            const mockResultReadable: ResultReadable = new ResultReadable(testTransactionId, testExecuteResult, mockCommunicator);
 
-            const result: Result = await Result.bufferResultStream(<ResultStream> mockResultStream);
+            const result: Result = await Result.bufferResultReadable(<ResultReadable> mockResultReadable);
             const resultList: dom.Value[] = result.getResultList();
 
             chai.assert.equal(values.length, resultList.length);

--- a/src/test/Transaction.test.ts
+++ b/src/test/Transaction.test.ts
@@ -32,7 +32,7 @@ import * as Errors from "../errors/Errors";
 import * as LogUtil from "../LogUtil";
 import { QldbHash } from "../QldbHash";
 import { Result } from "../Result";
-import { ResultStream } from "../ResultStream";
+import { ResultReadable } from "../ResultReadable";
 import { Transaction } from "../Transaction";
 import { expect } from "chai";
 
@@ -267,7 +267,7 @@ describe("Transaction", () => {
 
     describe("#executeAndStreamResults()", () => {
         it("should return a Stream object when provided with a statement", async () => {
-            const sampleResultStreamObject: ResultStream = new ResultStream(
+            const sampleResultReadableObject: ResultReadable = new ResultReadable(
                 testTransactionId,
                 testExecuteStatementResult,
                 mockCommunicator
@@ -276,11 +276,11 @@ describe("Transaction", () => {
             const result: Readable = await transaction.executeAndStreamResults(testStatement);
             sinon.assert.calledOnce(executeSpy);
             sinon.assert.calledWith(executeSpy, testTransactionId, testStatement, []);
-            chai.assert.equal(JSON.stringify(result), JSON.stringify(sampleResultStreamObject));
+            chai.assert.equal(JSON.stringify(result), JSON.stringify(sampleResultReadableObject));
         });
 
         it("should return a Stream object when provided with a statement and parameters", async () => {
-            const sampleResultStreamObject: ResultStream = new ResultStream(
+            const sampleResultReadableObject: ResultReadable = new ResultReadable(
                 testTransactionId,
                 testExecuteStatementResult,
                 mockCommunicator
@@ -291,7 +291,7 @@ describe("Transaction", () => {
             const result: Readable = await transaction.executeAndStreamResults(testStatement, param1, param2);
             sinon.assert.calledOnce(sendExecuteSpy);
             sinon.assert.calledWith(sendExecuteSpy, testStatement, [param1, param2]);
-            chai.assert.equal(JSON.stringify(result), JSON.stringify(sampleResultStreamObject));
+            chai.assert.equal(JSON.stringify(result), JSON.stringify(sampleResultReadableObject));
         });
 
         it("should return a rejected promise when error is thrown", async () => {

--- a/src/test/TransactionExecutor.test.ts
+++ b/src/test/TransactionExecutor.test.ts
@@ -20,7 +20,7 @@ import * as sinon from "sinon";
 
 import { LambdaAbortedError } from "../errors/Errors";
 import { Result } from "../Result";
-import { ResultStream } from "../ResultStream";
+import { ResultReadable } from "../ResultReadable";
 import { Transaction } from "../Transaction";
 import { TransactionExecutor } from "../TransactionExecutor";
 
@@ -32,7 +32,7 @@ const testMessage: string = "foo";
 const testTransactionId: string = "txnId";
 
 const mockResult: Result = <Result><any> sandbox.mock(Result);
-const mockResultStream: ResultStream = <ResultStream><any> sandbox.mock(ResultStream);
+const mockResultReadable: ResultReadable = <ResultReadable><any> sandbox.mock(ResultReadable);
 const mockTransaction: Transaction = <Transaction><any> sandbox.mock(Transaction);
 
 let transactionExecutor: TransactionExecutor;
@@ -100,23 +100,23 @@ describe("TransactionExecutor", () => {
     describe("#executeAndStreamResults()", () => {
         it("should return a Result object when provided with a statement", async () => {
             mockTransaction.executeAndStreamResults = async () => {
-                return mockResultStream;
+                return mockResultReadable;
             };
             const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeAndStreamResults");
-            const resultStream = await transactionExecutor.executeAndStreamResults(testStatement);
-            chai.assert.equal(mockResultStream, resultStream);
+            const resultReadable = await transactionExecutor.executeAndStreamResults(testStatement);
+            chai.assert.equal(mockResultReadable, resultReadable);
             sinon.assert.calledOnce(transactionExecuteSpy);
             sinon.assert.calledWith(transactionExecuteSpy, testStatement);
         });
 
         it("should return a Result object when provided with a statement and parameters", async () => {
             mockTransaction.executeAndStreamResults = async () => {
-                return mockResultStream;
+                return mockResultReadable;
             };
 
             const transactionExecuteSpy = sandbox.spy(mockTransaction, "executeAndStreamResults");
-            const resultStream = await transactionExecutor.executeAndStreamResults(testStatement, [5]);
-            chai.assert.equal(mockResultStream, resultStream);
+            const resultReadable = await transactionExecutor.executeAndStreamResults(testStatement, [5]);
+            chai.assert.equal(mockResultReadable, resultReadable);
             sinon.assert.calledOnce(transactionExecuteSpy);
             sinon.assert.calledWith(transactionExecuteSpy, testStatement, [5]);
         });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Rename `ResultStream` to `ResultReadable`
- Changing the return type of `executeAndStreamResults()` from `Readable` to `ResultReadable` - This change is backward compatible as `ResultReadable` extends `Readable`
- Export `ResultReadable`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
