### PR TITLE
Record any error encountered while sending a command and log a warn

### DIFF
--- a/src/Communicator.ts
+++ b/src/Communicator.ts
@@ -190,8 +190,13 @@ export class Communicator {
      * @returns Promise which fulfills with a SendCommandResult object.
      */
     private async _sendCommand(request: SendCommandRequest): Promise<SendCommandResult> {
-        const result: SendCommandResult = await this._qldbClient.sendCommand(request).promise();
-        debug(`Received response: ${inspect(result, { depth: 2 })}`);
-        return result;
+        try {
+            const result = await this._qldbClient.sendCommand(request).promise();
+            debug(`Received response: ${inspect(result, { depth: 2 })}`);
+            return result;
+        } catch (e) {
+            warn(`Error sending a command: ${e}.`);
+            throw e;
+        }
     }
 }

--- a/src/test/Communicator.test.ts
+++ b/src/test/Communicator.test.ts
@@ -257,7 +257,7 @@ describe("Communicator", () => {
             };
             sinon.assert.calledTwice(sendCommandStub);
             sinon.assert.calledWith(sendCommandStub, testRequest);
-            sinon.assert.calledOnce(logSpy);
+            sinon.assert.calledTwice(logSpy);
         });
     });
 


### PR DESCRIPTION
It's difficult to diagnose failures with the driver as they get bubbled as exceptions and are missing from the logs. This adds them to the log when there is an error on `sendCommand`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
