### PR TITLE
Add node 14.x to GitHub actions

### DIFF
--- a/.github/workflows/nodeapp.yml
+++ b/.github/workflows/nodeapp.yml
@@ -9,13 +9,13 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - name: Configure AWS Credentials

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=0.8.10"
+    "node": ">=10.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.10",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are supporting Node 10.x as the minimum version as per pre-req [docs](https://docs.aws.amazon.com/qldb/latest/developerguide/getting-started.nodejs.html#getting-started.nodejs.prereqs). 

Also [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) is supporting Node 14.x version.

Updating the GitHub actions to reflect this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
