### PR TITLE
Add test to ensure session state is clean during retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^6.5.1",
     "eslint-plugin-jsdoc": "^15.12.0",
     "grunt": "^1.0.4",
-    "ion-js": "^4.0.0",
+    "ion-js": "4.1.0",
     "jsbi": "^3.1.1",
     "mocha": "^6.2.0",
     "mocha-param": "^2.0.1",


### PR DESCRIPTION
* Ion version locked to 4.1.0 temporarily until investigation of Ion changes in 4.2 are completed by @byronlin13 
