### PR TITLE
Update element retrieval to use get()

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^6.5.1",
     "eslint-plugin-jsdoc": "^15.12.0",
     "grunt": "^1.0.4",
-    "ion-js": "4.1.0",
+    "ion-js": "^4.0.0",
     "jsbi": "^3.1.1",
     "mocha": "^6.2.0",
     "mocha-param": "^2.0.1",

--- a/src/integrationtest/StatementExecution.test.ts
+++ b/src/integrationtest/StatementExecution.test.ts
@@ -121,7 +121,7 @@ describe("StatementExecution", function() {
             // {
             //    expr: "[MyColumn]"
             // }
-            const indexColumn: string = result.getResultList()[0].elements()[0].stringValue();
+            const indexColumn: string = result.getResultList()[0].get("expr").stringValue();
             return indexColumn;
         });
         chai.assert.equal(indexColumn, "[" + constants.INDEX_ATTRIBUTE + "]");
@@ -219,7 +219,7 @@ describe("StatementExecution", function() {
             // {
             //    _1: 1
             // }
-            return (await txn.execute(searchQuery)).getResultList()[0].elements()[0].numberValue();
+            return (await txn.execute(searchQuery)).getResultList()[0].get("_1").numberValue();
         });
 
         chai.assert.equal(searchCount, 0);
@@ -283,7 +283,7 @@ describe("StatementExecution", function() {
             // {
             //    _1: 1
             // }
-            return (await txn.execute(searchQuery)).getResultList()[0].elements()[0].numberValue();
+            return (await txn.execute(searchQuery)).getResultList()[0].get("_1").numberValue();
         });
         chai.assert.equal(searchCount, 0);
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Revert `ion-js` dependency to `^4.0.0`
* Update Ion struct element retrieval to use `get()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
