### PR TITLE
[WIP] Update DefaultRetryConfig.ts

### DIFF
--- a/src/retry/DefaultRetryConfig.ts
+++ b/src/retry/DefaultRetryConfig.ts
@@ -19,6 +19,7 @@ const SLEEP_BASE_MS: number = 10;
 
 /**
  * A default backoff function which returns the amount of time(in milliseconds) to delay the next retry attempt
+ * Reference: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
  * 
  * @param retryAttempt The number of attempts done till now 
  * @param error The error that occurred while executing the previous transaction
@@ -27,9 +28,8 @@ const SLEEP_BASE_MS: number = 10;
  * @internal
  */
 export const defaultBackoffFunction: BackoffFunction = (retryAttempt: number, error: Error, transactionId: string) => {
-    const exponentialBackoff: number = Math.min(SLEEP_CAP_MS, Math.pow(SLEEP_BASE_MS * 2,  retryAttempt));
-    const jitterRand: number = Math.random();
-    const delayTime: number = jitterRand * exponentialBackoff;
+    const fullJitterBackoffMax: number = Math.min(SLEEP_CAP_MS, SLEEP_BASE_MS * 2 ** retryAttempt);
+    const delayTime: number = Math.random() * fullJitterBackoffMax;
     return delayTime;
 }
 


### PR DESCRIPTION
Fix order of operations error on backoff maximum. Was (SLEEP_BASE_MS * 2 ** retryAttempt ), and is now SLEEP_BASE_MS * 2 ** retryAttempt, which aligns with the full jitter algorithm.

- User reported random Lambda functions timing out during load testing. 

Fix: align backoff to Full Jitter algorithm, previous implementation was orders of magnitude off from Order of Operation error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
