### PR TITLE
bug fix when session is null

### DIFF
--- a/src/QldbDriver.ts
+++ b/src/QldbDriver.ts
@@ -11,30 +11,22 @@
  * and limitations under the License.
  */
 
-import { 
-    QLDBSession,  
-    QLDBSessionClient,   
-    QLDBSessionClientConfig,  
-} from "@aws-sdk/client-qldb-session";
-import { globalAgent } from "http";
-import { dom } from "ion-js";
+import {QLDBSession, QLDBSessionClient, QLDBSessionClientConfig,} from "@aws-sdk/client-qldb-session";
+import {globalAgent} from "http";
+import {dom} from "ion-js";
 import Semaphore from "semaphore-async-await";
 
-import { version } from "../package.json";
-import { Communicator } from "./Communicator";
-import {
-    DriverClosedError,
-    ExecuteError,
-    SessionPoolEmptyError,
- } from "./errors/Errors";
-import { debug, info } from "./LogUtil";
-import { QldbSession } from "./QldbSession";
-import { Result } from "./Result";
-import { BackoffFunction } from "./retry/BackoffFunction";
-import { defaultRetryConfig } from "./retry/DefaultRetryConfig";
-import { RetryConfig } from "./retry/RetryConfig";
-import { TransactionExecutor } from "./TransactionExecutor";
-import { NodeHttpHandler, NodeHttpHandlerOptions } from "@aws-sdk/node-http-handler";
+import {version} from "../package.json";
+import {Communicator} from "./Communicator";
+import {DriverClosedError, ExecuteError, SessionPoolEmptyError,} from "./errors/Errors";
+import {debug, info} from "./LogUtil";
+import {QldbSession} from "./QldbSession";
+import {Result} from "./Result";
+import {BackoffFunction} from "./retry/BackoffFunction";
+import {defaultRetryConfig} from "./retry/DefaultRetryConfig";
+import {RetryConfig} from "./retry/RetryConfig";
+import {TransactionExecutor} from "./TransactionExecutor";
+import {NodeHttpHandler, NodeHttpHandlerOptions} from "@aws-sdk/node-http-handler";
 
 /**
   * This is the entry point for all interactions with Amazon QLDB.
@@ -175,7 +167,7 @@ export class QldbDriver {
      * @throws {@linkcode DriverClosedError} When a transaction is attempted on a closed driver instance. {@linkcode close}
      * @throws {@linkcode ClientException} When the commit digest from commit transaction result does not match.
      * @throws {@linkcode SessionPoolEmptyError} When maxConcurrentTransactions limit is reached and there is no session available in the pool.
-     * @throws {@linkcode InvalidSessionException} When a session expires either due to a long running transaction or session being idle for long time.
+     * @throws {@linkcode InvalidSessionException} When a session expires either due to a long-running transaction or session being idle for long time.
      * @throws {@linkcode BadRequestException} When Amazon QLDB is not able to execute a query or transaction.
      */
     async executeLambda<T>(
@@ -186,59 +178,15 @@ export class QldbDriver {
             throw new DriverClosedError();
         }
 
-        // Acquire semaphore and get a session from the pool
-        const getSession = async function(thisDriver: QldbDriver): Promise<QldbSession> {
-            debug(
-                `Getting session. Current free session count: ${thisDriver._sessionPool.length}. ` +
-                `Currently available permit count: ${thisDriver._semaphore.getPermits()}.`
-            );
-            if (thisDriver._semaphore.tryAcquire()) {
-                let session = thisDriver._sessionPool.pop();                
-                if (session == undefined) {
-                    debug(`Creating a new pooled session.`);
-                    session = await createNewSession(thisDriver);
-                }
-                return session;
-            } else {
-                throw new SessionPoolEmptyError()
-            }
-        }
-
-        const createNewSession = async(thisDriver: QldbDriver) => {
-            try {
-                const communicator: Communicator =             
-                await Communicator.create(thisDriver._qldbClient, thisDriver._ledgerName);
-                return new QldbSession(communicator);
-            } catch (e) {
-                // An error when failing to start a new session is always retryable
-                throw new ExecuteError(e as Error, true, true);
-            }
-        }
-
-        // Release semaphore and if the session is alive return it to the pool and return true
-        const releaseSession = function(thisDriver: QldbDriver, session: QldbSession): boolean {
-            if (session != null && session.isAlive()) {
-                thisDriver._sessionPool.push(session);
-                thisDriver._semaphore.release();
-                debug(`Session returned to pool; pool size is now: ${thisDriver._sessionPool.length}`)
-                return true
-            } else if (session != null) {
-                thisDriver._semaphore.release();
-                return false;
-            } else {
-                return false;
-            }
-        }
-        
         retryConfig = (retryConfig == null) ? this._retryConfig : retryConfig;
         let replaceDeadSession: boolean = false;
         for (let retryAttempt: number = 1; true; retryAttempt++) {
             let session: QldbSession = null;
             try {
                 if (replaceDeadSession) {
-                    await createNewSession(this);
+                    session = await this.createNewSession(this);
                 } else {
-                    session = await getSession(this);
+                    session = await this.getSession(this);
                 }
                 return await session.executeLambda(transactionLambda);
             } catch (e) {
@@ -270,8 +218,53 @@ export class QldbDriver {
                     throw e;
                 }
             } finally {
-                replaceDeadSession = !releaseSession(this, session);
+                replaceDeadSession = !this.releaseSession(this, session);
             }
+        }
+    }
+
+    // Release semaphore and if the session is alive return it to the pool and return true
+    private releaseSession(thisDriver: QldbDriver, session: QldbSession): boolean {
+        if (session != null && session.isAlive()) {
+            thisDriver._sessionPool.push(session);
+            thisDriver._semaphore.release();
+            debug(`Session returned to pool; pool size is now: ${thisDriver._sessionPool.length}`)
+            return true
+        } else if (session != null) {
+            thisDriver._semaphore.release();
+            return false;
+        } else {
+            return false;
+        }
+    }
+
+
+    // Acquire semaphore and get a session from the pool
+    private async getSession(thisDriver: QldbDriver): Promise<QldbSession> {
+        debug(
+          `Getting session. Current free session count: ${thisDriver._sessionPool.length}. ` +
+          `Currently available permit count: ${thisDriver._semaphore.getPermits()}.`
+        );
+        if (thisDriver._semaphore.tryAcquire()) {
+            let session = thisDriver._sessionPool.pop();
+            if (session == undefined) {
+                debug(`Creating a new pooled session.`);
+                session = await this.createNewSession(thisDriver);
+            }
+            return session;
+        } else {
+            throw new SessionPoolEmptyError()
+        }
+    }
+
+    private async createNewSession(thisDriver: QldbDriver) {
+        try {
+            const communicator: Communicator =
+            await Communicator.create(thisDriver._qldbClient, thisDriver._ledgerName);
+            return new QldbSession(communicator);
+        } catch (e) {
+            // An error when failing to start a new session is always retryable
+            throw new ExecuteError(e as Error, true, true);
         }
     }
 
@@ -284,9 +277,9 @@ export class QldbDriver {
         return await this.executeLambda(async (transactionExecutor: TransactionExecutor) : Promise<string[]> => {
             const result: Result = await transactionExecutor.execute(statement);
             const resultStructs: dom.Value[] = result.getResultList();
-            const listOfTableNames: string[] = resultStructs.map(tableNameStruct =>
-                tableNameStruct.get("name").stringValue());
-            return listOfTableNames;
+
+            return resultStructs.map(tableNameStruct =>
+              tableNameStruct.get("name").stringValue());
         });
     }
 }

--- a/src/QldbDriver.ts
+++ b/src/QldbDriver.ts
@@ -11,22 +11,30 @@
  * and limitations under the License.
  */
 
-import {QLDBSession, QLDBSessionClient, QLDBSessionClientConfig,} from "@aws-sdk/client-qldb-session";
-import {globalAgent} from "http";
-import {dom} from "ion-js";
+import {
+    QLDBSession,
+    QLDBSessionClient,
+    QLDBSessionClientConfig,
+} from "@aws-sdk/client-qldb-session";
+import { globalAgent } from "http";
+import { dom } from "ion-js";
 import Semaphore from "semaphore-async-await";
 
-import {version} from "../package.json";
-import {Communicator} from "./Communicator";
-import {DriverClosedError, ExecuteError, SessionPoolEmptyError,} from "./errors/Errors";
-import {debug, info} from "./LogUtil";
-import {QldbSession} from "./QldbSession";
-import {Result} from "./Result";
-import {BackoffFunction} from "./retry/BackoffFunction";
-import {defaultRetryConfig} from "./retry/DefaultRetryConfig";
-import {RetryConfig} from "./retry/RetryConfig";
-import {TransactionExecutor} from "./TransactionExecutor";
-import {NodeHttpHandler, NodeHttpHandlerOptions} from "@aws-sdk/node-http-handler";
+import { version } from "../package.json";
+import { Communicator } from "./Communicator";
+import {
+    DriverClosedError,
+    ExecuteError,
+    SessionPoolEmptyError,
+} from "./errors/Errors";
+import { debug, info } from "./LogUtil";
+import { QldbSession } from "./QldbSession";
+import { Result } from "./Result";
+import { BackoffFunction } from "./retry/BackoffFunction";
+import { defaultRetryConfig } from "./retry/DefaultRetryConfig";
+import { RetryConfig } from "./retry/RetryConfig";
+import { TransactionExecutor } from "./TransactionExecutor";
+import { NodeHttpHandler, NodeHttpHandlerOptions } from "@aws-sdk/node-http-handler";
 
 /**
   * This is the entry point for all interactions with Amazon QLDB.


### PR DESCRIPTION
*Issue #223, if available:*

*Description of changes:*

When running load tests into our current setup, when session is not live and a new one needs to be created, the session is null resulting on an error `Cannot read properties of null (reading 'executeLambda')`

The problem is that session var is not getting the new session recently created and it fails.  

The problem only appears after 10/15 minutes running continuos requests to QLDB.  We tried setting some timeout settings without success.

I have to extract method to private methods to make it easier to mock and test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
