### PR TITLE
fix external party PR GH Actions workflow

### DIFF
--- a/.github/workflows/nodeapp.yml
+++ b/.github/workflows/nodeapp.yml
@@ -10,6 +10,9 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    permissions:
+        id-token: write
+        contents: read
 
     strategy:
       max-parallel: 3


### PR DESCRIPTION
Our GitHub action aws-actions/configure-aws-credentials is failing when 3rd parties PR. 

Known issue: https://github.com/aws-actions/configure-aws-credentials/issues/271

README documenting config: https://github.com/aws-actions/configure-aws-credentials#usage

```
# These permissions are needed to interact with GitHub's OIDC Token endpoint.
    permissions:
      id-token: write
      contents: read
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
