### PR TITLE
actions: use OIDC aws credentials

### DIFF
--- a/.github/workflows/nodeapp.yml
+++ b/.github/workflows/nodeapp.yml
@@ -24,10 +24,8 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
         aws-region: us-east-1
+        role-to-assume: arn:aws:iam::264319671630:role/GitHubActionsOidc
 
     - uses: actions/checkout@v2
   


### PR DESCRIPTION
Use OIDC for aws-actions/configure-aws-credentials, as is the new guidance. This also allows us to remove the repo secrets, and opens up the ability for third-party contributors to have their code automatically checked by GH Actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
