### PR TITLE
update npm doc script for doc generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clean": "rm -rf node_modules",
     "reinstall": "npm ci",
     "build": "npm run lint && tsc",
-    "doc": "typedoc --out docs ./src --exclude **/*.test.ts",
+    "doc": "typedoc --out docs ./index.ts --exclude **/*.test.ts",
     "installAndPack": "npm install . && npm pack && rm $npm_package_name-$npm_package_version.tgz",
     "lint": "eslint src/**/*.ts",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Update typedoc target for documentation generator. This updates the typedoc target to the root directory index.ts file for the generator. That way, when you run `npm doc` for the repo, the documentation can be generated. Likely an artifact of moving the index.ts out of the ./src directory at some point.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
