### PR TITLE
Update aws-sdk to fix fast-xml-parser vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "node": ">=14.0.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-qldb": "^3.256.0",
-    "@aws-sdk/client-qldb-session": "^3.256.0",
+    "@aws-sdk/client-qldb": "^3.350.0",
+    "@aws-sdk/client-qldb-session": "^3.350.0",
     "@types/chai": "^4.3.1",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.0",


### PR DESCRIPTION
*Issue #, if available:*
Detects a vulnerability on the package of `fast-xml-parser`

*Description of changes:*
Update the `@aws-sdk/client-qldb` and `@@aws-sdk/client-qldb-session` to v3.350.0
