### PR TITLE
Add missing Smithy dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/smithy-client": "^2.1.13",
         "@types/node": "^20.11.24",
         "ion-hash-js": "^2.0.0",
         "semaphore-async-await": "^1.5.1"
@@ -1564,7 +1566,6 @@
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
       "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -1621,7 +1622,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.5.tgz",
       "integrity": "sha512-m9yoTx+64XRSpCzWArOpvHeAuVfI2LFz2hDzgzjzCLlN8IIwzkFaCav5ShsYxx4iu9sXp09+on0a5VROY9+MFQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/protocol-http": "^3.0.8",
         "@smithy/querystring-builder": "^2.0.12",
@@ -1659,7 +1659,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
       "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1735,7 +1734,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
       "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -1763,7 +1761,6 @@
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
       "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
-      "dev": true,
       "dependencies": {
         "@smithy/abort-controller": "^2.0.12",
         "@smithy/protocol-http": "^3.0.8",
@@ -1792,7 +1789,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
       "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
         "tslib": "^2.5.0"
@@ -1805,7 +1801,6 @@
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
       "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
-      "dev": true,
       "dependencies": {
         "@smithy/types": "^2.4.0",
         "@smithy/util-uri-escape": "^2.0.0",
@@ -1876,7 +1871,6 @@
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.13.tgz",
       "integrity": "sha512-iFqrjps6K/eLNbDKppyp5gCCZyEtv/BYMlDSBXwwHIrwV7sZ8l8r6OGAcg1a69j4Id1uJccYppaTpW5G1BLhsA==",
-      "dev": true,
       "dependencies": {
         "@smithy/middleware-stack": "^2.0.6",
         "@smithy/types": "^2.4.0",
@@ -1891,7 +1885,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
       "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1914,7 +1907,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
       "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -1948,7 +1940,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
       "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.0.0",
         "tslib": "^2.5.0"
@@ -2021,7 +2012,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
       "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2060,7 +2050,6 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.18.tgz",
       "integrity": "sha512-e/a7JrmHTy+gxHjdJKHQFyK8X2SCoJEaBXTrs5Q/HS69a3P4P0Mbu1znKFKFM/fDtppCxPCO0IcIbNvbVSEJ8w==",
-      "dev": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^2.2.5",
         "@smithy/node-http-handler": "^2.1.8",
@@ -2079,7 +2068,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
       "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2091,7 +2079,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.1.tgz",
       "integrity": "sha512-JvpZMUTMIil6rstH3tyBjCE7tuTmCprcmCXHW4o8a5mSthhQ8fEj5lDWOonTigtB2CqiBQ/SWlpoctuzVO7J0Q==",
-      "dev": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.0.0",
         "tslib": "^2.5.0"
@@ -6043,8 +6030,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "@smithy/node-http-handler": "^2.1.8",
+    "@smithy/smithy-client": "^2.1.13",
     "@types/node": "^20.11.24",
     "ion-hash-js": "^2.0.0",
     "semaphore-async-await": "^1.5.1"


### PR DESCRIPTION
*Description of changes:* Added explicit dependencies to `@smithy/smithy-client` and `@smithy/node-http-handler`, as they were not declared, which causes phantom dependency issues in non-hoisting package managers such as `pnpm` (with hoisting disabled, as used by Bazel, for example). I've chosen the same version qualifier/selector that is used in transitive dependencies to avoid any unexpected package version variations. This should not affect any of this package's consumers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
