### PR TITLE
Add missing Smithy dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/smithy-client": "^2.5.0",
         "@types/node": "^20.11.24",
         "ion-hash-js": "^2.0.0",
         "semaphore-async-await": "^1.5.1"
@@ -1561,13 +1563,12 @@
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-      "integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1618,16 +1619,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.5.tgz",
-      "integrity": "sha512-m9yoTx+64XRSpCzWArOpvHeAuVfI2LFz2hDzgzjzCLlN8IIwzkFaCav5ShsYxx4iu9sXp09+on0a5VROY9+MFQ==",
-      "dev": true,
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-node": {
@@ -1656,12 +1656,11 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1682,18 +1681,17 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.5.tgz",
-      "integrity": "sha512-eRhI0mI9tnkpmLwJbprV+MdlPyOMe8tFtVrNFMUlgOQrJeYv5AD5UFRn/KhgNX1vO1pVgpPtD9R+cRuFhj/lIQ==",
-      "dev": true,
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.0.tgz",
+      "integrity": "sha512-OBhI9ZEAG8Xen0xsFJwwNOt44WE2CWkfYIxTognC8x42Lfsdf0VN/wCMqpdkySMDio/vts10BiovAxQp0T0faA==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/node-config-provider": "^2.1.4",
-        "@smithy/shared-ini-file-loader": "^2.2.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1719,110 +1717,102 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-      "integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-      "integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.4.tgz",
-      "integrity": "sha512-kROLnHFatpimtmZ8YefsRRb5OJ8LVIVNhUWp67KHL4D2Vjd+WpIHMzWtkLLV4p0qXpY+IxmwcL2d2XMPn8ppsQ==",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.13",
-        "@smithy/shared-ini-file-loader": "^2.2.3",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-      "integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
-      "dev": true,
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.12",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/querystring-builder": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-      "integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-      "integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-      "dev": true,
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-      "integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-      "integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1841,13 +1831,12 @@
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.3.tgz",
-      "integrity": "sha512-VDyhCNycPbNkPidMnBgYQeSwJkoATRFm5VrveVqIPAjsdGutf7yZpPycuDWW9bRFnuuwaBhCC0pA7KCH0+2wrg==",
-      "dev": true,
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1873,51 +1862,50 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.13.tgz",
-      "integrity": "sha512-iFqrjps6K/eLNbDKppyp5gCCZyEtv/BYMlDSBXwwHIrwV7sZ8l8r6OGAcg1a69j4Id1uJccYppaTpW5G1BLhsA==",
-      "dev": true,
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.0.tgz",
+      "integrity": "sha512-DDXWHWdimtS3y/Kw1Jo46KQ0ZYsDKcldFynQERUGBPDpkW1lXOTHy491ALHjwfiBQvzsVKVxl5+ocXNIgJuX4g==",
       "dependencies": {
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-stream": "^2.0.18",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-      "integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-      "dev": true,
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-      "integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
-      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1945,13 +1933,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2018,25 +2005,23 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-      "integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2057,44 +2042,41 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.18.tgz",
-      "integrity": "sha512-e/a7JrmHTy+gxHjdJKHQFyK8X2SCoJEaBXTrs5Q/HS69a3P4P0Mbu1znKFKFM/fDtppCxPCO0IcIbNvbVSEJ8w==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.2.5",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.1.tgz",
-      "integrity": "sha512-JvpZMUTMIil6rstH3tyBjCE7tuTmCprcmCXHW4o8a5mSthhQ8fEj5lDWOonTigtB2CqiBQ/SWlpoctuzVO7J0Q==",
-      "dev": true,
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6043,8 +6025,7 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "@smithy/node-http-handler": "^2.5.0",
+    "@smithy/smithy-client": "^2.5.0",
     "@types/node": "^20.11.24",
     "ion-hash-js": "^2.0.0",
     "semaphore-async-await": "^1.5.1"


### PR DESCRIPTION
Resubmission of #651 while we debug creds retrieval.

> _Description of changes_: Added explicit dependencies to @smithy/smithy-client and @smithy/node-http-handler, as they were not declared, which causes phantom dependency issues in non-hoisting package managers such as pnpm (with hoisting disabled, as used by Bazel, for example). ~~I've chosen the same version qualifier/selector that is used in transitive dependencies to avoid any unexpected package version variations.~~ This should not affect any of this package's consumers.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
